### PR TITLE
Fix c-ares linker problem when USE_SRV:=yes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ CFLAGS += $(BACKENDS) $(BE_CFLAGS) -I$(MOSQ)/src -DDEBUG=1 $(OSSLINC)
 LDFLAGS = $(BE_LDFLAGS) -L$(MOSQUITTO_SRC)/lib/
 # LDFLAGS += -Wl,-rpath,$(../../../../pubgit/MQTT/mosquitto/lib) -lc
 # LDFLAGS += -export-dynamic
+LDFLAGS += -lcares
 LDADD = $(BE_LDADD) $(OSSLIBS) -lmosquitto
 
 all: printconfig auth-plug.so np


### PR DESCRIPTION
Fix dynamic linker problem when USE_SRV is true in Mosquitto by
linking to c-ares here.
