### PR TITLE
MongoDB skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,16 @@ ifneq ($(BACKEND_HTTP), no)
 	OBJS += be-http.o
 endif
 
+ifneq ($(BACKEND_MONGO), no)
+	BACKENDS+= -DBE_MONGO
+	BACKENDSTR += MongoDB
+
+	BE_CFLAGS += -I/usr/local/include/ 
+	BE_LDFLAGS += -L/usr/local/lib
+	BE_LDADD += -lmongoc-1.0 -lbson-1.0
+	OBJS += be-mongo.o
+endif
+
 OSSLINC = -I$(OPENSSLDIR)/include
 OSSLIBS = -L$(OPENSSLDIR)/lib -lcrypto
 
@@ -121,6 +131,7 @@ hash.o: hash.c hash.h uthash.h Makefile
 be-postgres.o: be-postgres.c be-postgres.h Makefile
 cache.o: cache.c cache.h uthash.h Makefile
 be-http.o: be-http.c be-http.h Makefile backends.h
+be-mongo.o: be-mongo.c be-mongo.h Makefile
 
 np: np.c base64.o
 	$(CC) $(CFLAGS) $^ -o $@ $(OSSLIBS)

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ This plugin can perform authentication (check username / password)
 and authorization (ACL). Currently not all back-ends have the same capabilities
 (the the section on the back-end you're interested in).
 
-| Capability                 | mysql | redis | cdb   | sqlite | ldap | psk | postgres | http |
-| -------------------------- | :---: | :---: | :---: | :---:  | :-:  | :-: | :------: | :--: |
-| authentication             |   Y   |   Y   |   Y   |   Y    |  Y   |  Y  |    Y     |  Y   |
-| superusers                 |   Y   |       |       |        |      |  2  |    Y     |  Y   |
-| acl checking               |   Y   |   1   |   1   |   1    |      |  2  |    Y     |  Y   |
-| static superusers          |   Y   |   Y   |   Y   |   Y    |      |  2  |    Y     |  Y   |
+| Capability                 | mysql | redis | cdb   | sqlite | ldap | psk | postgres | http | MongoDB |
+| -------------------------- | :---: | :---: | :---: | :---:  | :-:  | :-: | :------: | :--: | :-----: |
+| authentication             |   Y   |   Y   |   Y   |   Y    |  Y   |  Y  |    Y     |  Y   |  Y      |
+| superusers                 |   Y   |       |       |        |      |  2  |    Y     |  Y   |         |
+| acl checking               |   Y   |   Y   |   1   |   1    |      |  2  |    Y     |  Y   |  1      |
+| static superusers          |   Y   |   Y   |   Y   |   Y    |      |  2  |    Y     |  Y   |  Y      |
 
  1. Currently not implemented; back-end returns TRUE
  2. Dependent on the database used by PSK
@@ -36,7 +36,7 @@ The configuration option is called `auth_opt_backends` and it takes a
 comma-separated list of back-end names which are checked in exactly that order.
 
 ```
-auth_opt_backends cdb,sqlite,mysql,redis,postgres
+auth_opt_backends cdb,sqlite,mysql,redis,postgres,http,mongo
 ```
 
 Note: anonymous MQTT connections are assigned a username of configured in the

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ of several distinct back-ends:
 * TLS PSK (the `psk` back-end is a bit of a shim which piggy-backs onto the other database back-ends)
 * LDAP
 * HTTP (custom HTTP API)
+* MongoDB
 
 ## Introduction
 

--- a/auth-plug.c
+++ b/auth-plug.c
@@ -48,6 +48,7 @@
 #include "be-postgres.h"
 #include "be-ldap.h"
 #include "be-http.h"
+#include "be-mongo.h"
 
 #include "userdata.h"
 #include "cache.h"
@@ -318,6 +319,24 @@ int mosquitto_auth_plugin_init(void **userdata, struct mosquitto_auth_opt *auth_
 			PSKSETUP;
 		}
 #endif
+
+#if BE_MONGO
+		if (!strcmp(q, "mongo")) {
+			*bep = (struct backend_p *)malloc(sizeof(struct backend_p));
+			memset(*bep, 0, sizeof(struct backend_p));
+			(*bep)->name = strdup("mongo");
+			(*bep)->conf = be_mongo_init();
+			if ((*bep)->conf == NULL) {
+				_fatal("%s init returns NULL", q);
+			}
+			(*bep)->kill =  be_mongo_destroy;
+			(*bep)->getuser =  be_mongo_getuser;
+			(*bep)->superuser =  be_mongo_superuser;
+			(*bep)->aclcheck =  be_mongo_aclcheck;
+			found = 1;
+			PSKSETUP;
+		}
+#endif		
                 if (!found) {
                         _fatal("ERROR: configured back-end `%s' is not compiled in this plugin", q);
                 }

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -1,0 +1,129 @@
+/*
+ * Original Work: 
+ *      Copyright (c) 2014 zhangxj <zxj_2007_happy@163.com>
+ * Modified and Adapted for Mosquitto_auth_plug by: 
+ *         Gopalakrishna Palem < http://gk.palem.in/ >
+ */
+
+#ifdef BE_MONGO
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mongoc.h>
+#include "hash.h"
+
+struct mongo_backend {
+    mongoc_client_t *client;
+    char *host;
+    int port;
+};
+
+void *be_mongo_init()
+{
+    struct mongo_backend *conf;
+    char *host, *p;
+
+    if ((host = p_stab("mongo_host")) == NULL)
+        host = "localhost";
+    if ((p = p_stab("mongo_port")) == NULL)
+        p = "27017";
+
+     char uristr[128] = {0};
+     strcpy(uristr, "mongodb://");
+     strcat(uristr, host);
+     strcat(uristr, ":");
+     strcat(uristr, p);
+     printf("mongo: [%s]\n", uristr);
+   //"mongodb://127.0.0.1:27017/";
+
+    conf = (struct mongo_backend *)malloc(sizeof(struct mongo_backend));
+   mongoc_init ();
+
+   conf->client = mongoc_client_new (uristr);
+
+   if (!conf->client) {
+      fprintf (stderr, "Failed to parse URI.\n");
+      return NULL;
+   }
+    return (conf);
+}
+
+char *be_mongo_getuser(void *handle, const char *username, const char *password, int *authenticated)
+{
+    struct mongo_backend *conf = (struct mongo_backend *)handle;
+   mongoc_collection_t *collection;
+   mongoc_cursor_t *cursor;
+   bson_error_t error;
+   const bson_t *doc;
+   const char *collection_name = "passport";
+   bson_t query;
+   char *str = NULL;
+   char *result = malloc(33);
+   memset(result, 0, 33);
+
+   bson_init (&query);
+
+   bson_append_utf8 (&query, "username", -1, username, -1);
+
+   collection = mongoc_client_get_collection (conf->client, "cas", collection_name);
+   cursor = mongoc_collection_find (collection,
+                                    MONGOC_QUERY_NONE,
+                                    0,
+                                    0,
+                                    0,
+                                    &query,
+                                    NULL,  /* Fields, NULL for all. */
+                                    NULL); /* Read Prefs, NULL for default */
+
+
+   bson_iter_t iter;
+   while (!mongoc_cursor_error (cursor, &error) &&
+          mongoc_cursor_more (cursor)) {
+      if (mongoc_cursor_next (cursor, &doc)) {
+
+         bson_iter_init(&iter, doc);
+         bson_iter_find(&iter, "pwd");
+         //fprintf (stdout, "%s\n", bson_iter_utf8(&iter, NULL));
+         str = bson_as_json (doc, NULL);
+         //fprintf (stdout, "%s\n", str);
+         bson_free (str);
+         char *src = (char *)bson_iter_utf8(&iter, NULL);
+         memcpy(result, src, strlen(src));
+      }
+   }
+
+   if (mongoc_cursor_error (cursor, &error)) {
+      fprintf (stderr, "Cursor Failure: %s\n", error.message);
+      return result;
+   }
+
+   bson_destroy (&query);
+   mongoc_cursor_destroy (cursor);
+   mongoc_collection_destroy (collection);
+   return result;
+}
+ 
+
+void be_mongo_destroy(void *handle)
+{
+    struct mongo_backend *conf = (struct mongo_backend *)handle;
+
+    if (conf != NULL) {
+        mongoc_client_destroy(conf->client);
+        conf->client = NULL;
+    }
+}
+
+int be_mongo_superuser(void *conf, const char *username)
+{
+	return 0;
+}
+
+int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, const char *topic, int acc)
+{
+	/* FIXME: implement. Currently TRUE */
+
+	return 1;
+}
+#endif /* BE_MONGO */

--- a/be-mongo.h
+++ b/be-mongo.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014 zhangxj <zxj_2007_happy@163.com>
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef BE_MONGO
+
+void *be_mongo_init();
+void be_mongo_destroy(void *conf);
+char *be_mongo_getuser(void *conf, const char *username, const char *password, int *authenticated);
+int be_mongo_superuser(void *conf, const char *username);
+int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, const char *topic, int acc);
+#endif /* BE_MONGO */

--- a/config.mk.in
+++ b/config.mk.in
@@ -6,6 +6,7 @@ BACKEND_REDIS ?= no
 BACKEND_POSTGRES ?= no
 BACKEND_LDAP ?= no
 BACKEND_HTTP ?= no
+BACKEND_MONGO ?= no
 
 # Specify the path to the Mosquitto sources here
 MOSQUITTO_SRC =


### PR DESCRIPTION
Basically same as https://github.com/jpmens/mosquitto-auth-plug/pull/22 - except, removed the objectionable parts and updated the prototypes to match the latest.

Auth method is implemented and ACL hard-coded to return 1. Framework for ACL is present for any MongoDB expert to just fill-in.
