### PR TITLE
env vars could be used as http request parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BE_CFLAGS =
 BE_LDFLAGS =
 BE_LDADD =
 BE_DEPS =
-OBJS = auth-plug.o base64.o pbkdf2-check.o log.o hash.o be-psk.o backends.o cache.o
+OBJS = auth-plug.o base64.o pbkdf2-check.o log.o envs.o hash.o be-psk.o backends.o cache.o
 
 BACKENDS =
 BACKENDSTR =
@@ -116,7 +116,7 @@ printconfig:
 auth-plug.so : $(OBJS) $(BE_DEPS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -fPIC -shared -o $@ $(OBJS) $(BE_DEPS) $(LDADD)
 
-be-redis.o: be-redis.c be-redis.h log.h hash.h Makefile
+be-redis.o: be-redis.c be-redis.h log.h hash.h envs.h Makefile
 be-sqlite.o: be-sqlite.c be-sqlite.h Makefile
 auth-plug.o: auth-plug.c be-cdb.h be-mysql.h be-sqlite.h Makefile cache.h
 be-psk.o: be-psk.c be-psk.h Makefile
@@ -127,6 +127,7 @@ be-sqlite.o: be-sqlite.c be-sqlite.h Makefile
 pbkdf2-check.o: pbkdf2-check.c base64.h Makefile
 base64.o: base64.c base64.h Makefile
 log.o: log.c log.h Makefile
+envs.o: envs.c envs.h Makefile
 hash.o: hash.c hash.h uthash.h Makefile
 be-postgres.o: be-postgres.c be-postgres.h Makefile
 cache.o: cache.c cache.h uthash.h Makefile

--- a/auth-plug.c
+++ b/auth-plug.c
@@ -39,6 +39,7 @@
 #include "log.h"
 #include "hash.h"
 #include "backends.h"
+#include "envs.h"
 
 #include "be-psk.h"
 #include "be-cdb.h"

--- a/be-http.c
+++ b/be-http.c
@@ -77,7 +77,11 @@ static int get_string_envs(CURL *curl, const char *required_env, char *querystri
 			return (-1);
 		}
 		sprintf(data, "%s=%s&", escaped_key, escaped_val);
-		strcat(querystring, data);
+		if ( i == 0 ) {
+			sprintf(querystring, "%s", data);
+		} else {
+			strcat(querystring, data);
+		}
 	}
 
 	free(data);

--- a/be-http.h
+++ b/be-http.h
@@ -26,8 +26,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
 #ifdef BE_HTTP
+
+#define MAXPARAMSLEN  1024
+#define METHOD_GETUSER   1
+#define METHOD_SUPERUSER 2
+#define METHOD_ACLCHECK  3
 
 struct http_backend {
 	char *ip;
@@ -36,6 +40,9 @@ struct http_backend {
 	char *getuser_uri;
 	char *superuser_uri;
 	char *aclcheck_uri;
+	char *getuser_envs;
+	char *superuser_envs;
+	char *aclcheck_envs;
 };
 
 void *be_http_init();

--- a/envs.c
+++ b/envs.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "envs.h"
+#include "log.h"
+
+int get_sys_envs(char *envs, const char *delim_env, const char *delim_key, char *params_key[], char *env_name[], char * env_value[]) {
+    char *tk;
+    int params_cnt = 0;
+
+    tk = strtok( envs, delim_env );
+    while( tk != NULL && params_cnt < MAXPARAMSNUM ) {
+        params_key[params_cnt++] = tk;
+        tk = strtok( NULL, delim_env );
+    }
+
+    int cnt = 0;
+
+    while( params_key[cnt] != NULL && cnt < params_cnt ){
+      tk = strtok( params_key[cnt], delim_key );
+      env_name[cnt] = strtok( NULL, delim_key );
+      params_key[cnt] = tk;
+      env_value[cnt] = getenv(env_name[cnt]) == NULL ? "NULL" : getenv(env_name[cnt]);
+      cnt++;
+    }
+    return params_cnt;
+}

--- a/envs.h
+++ b/envs.h
@@ -1,0 +1,3 @@
+#define MAXPARAMSNUM 20
+
+int get_sys_envs(char *envs, const char *delim_env, const char *delim_key, char *params_key[], char *env_name[], char * env_value[]);


### PR DESCRIPTION
## Abstract
In this p-r, env vars could be used as http request parameters.
## Configuration & How to use
Add config lines into the mosquitto.conf

```auth_opt_<interface>_<method>_params <key>=<evn_name>[,<key>=<evn_name>]* ```

eg for the Http interface :

1) Set these env vars like this
```
export DOMAIN=example.com
export PORT=8080
```
2) Add this configs in the mosquitto.conf
```
auth_opt_http_getuser_params domain=DOMAIN,port=PORT
auth_opt_http_superuser_params domain= DOMAIN,port=PORT
auth_opt_http_aclcheck_params domain= DOMAIN,port=PORT
```
3) The Http parameters will like
```
|-- url=http://127.0.0.1:8080/auth/
|-- data=domain=example.com&port=8080&username=xxx&password=ax&topic=&acc=-1&clientid=
```

```
|-- url=http://127.0.0.1:8080/superuser/
|-- data=domain=example.com&port=8080&username=xxx&password=&topic=&acc=-1&clientid=
```

```
|-- url=http://127.0.0.1:8080/acl/
|-- data=domain=example.com&port=8080&username=xxx&password=&topic=abc&acc=2&clientid=mosqpub/6349-mqttkaf001
```

We will be happy if you can accept our's code :)