### PR TITLE
Feature/enable to use https

### DIFF
--- a/be-http.c
+++ b/be-http.c
@@ -128,7 +128,13 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 		_fatal("ENOMEM");
 		return (FALSE);
 	}
-	sprintf(url, "http://%s:%d%s", conf->ip, conf->port, uri);
+	
+	// enable the https
+	if (strcpy(conf->with_ssl, "true") == 0){
+		sprintf(url, "https://%s:%d%s", conf->ip, conf->port, uri);
+	}else{
+		sprintf(url, "http://%s:%d%s", conf->ip, conf->port, uri);
+	}
 
 	char* escaped_username = curl_easy_escape(curl, username, 0);
 	char* escaped_password = curl_easy_escape(curl, password, 0);
@@ -250,7 +256,14 @@ void *be_http_init()
 	conf->getuser_envs = p_stab("http_getuser_params");
 	conf->superuser_envs = p_stab("http_superuser_params");
 	conf->aclcheck_envs = p_stab("http_aclcheck_params");
+	
+	if (p_stab("http_with_ssl") != NULL) {
+		conf->with_ssl = p_stab("http_with_ssl");
+	} else {
+		conf->with_ssl = "false";
+	}
 
+	_log(LOG_DEBUG, "with_ssl=%s", conf->with_ssl);
 	_log(LOG_DEBUG, "getuser_uri=%s", getuser_uri);
 	_log(LOG_DEBUG, "superuser_uri=%s", superuser_uri);
 	_log(LOG_DEBUG, "aclcheck_uri=%s", aclcheck_uri);

--- a/be-http.c
+++ b/be-http.c
@@ -130,7 +130,7 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 	}
 	
 	// enable the https
-	if (strcpy(conf->with_ssl, "true") == 0){
+	if (strcmp(conf->with_ssl, "true") == 0){
 		sprintf(url, "https://%s:%d%s", conf->ip, conf->port, uri);
 	}else{
 		sprintf(url, "http://%s:%d%s", conf->ip, conf->port, uri);

--- a/be-http.h
+++ b/be-http.h
@@ -43,6 +43,7 @@ struct http_backend {
 	char *getuser_envs;
 	char *superuser_envs;
 	char *aclcheck_envs;
+	char *with_ssl;
 };
 
 void *be_http_init();


### PR DESCRIPTION
## Abstract
In this p-r, https could be used  instead of http.
## Configuration & How to use
Add config lines into the mosquitto.conf, the defauls value is FALSE.

``` auth_opt_http_with_ssl true ```

eg :

1) Add this cnfigs in the mosquitto.conf
```
auth_opt_http_with_ssl true
```
2) The Https request will like
```
|-- url=https://example.com:443/auth/
|-- data=domain=example.com&port=8080&username=xxx&password=ax&topic=&acc=-1&clientid=
```

```
|-- url=https://example.com:443/superuser/
|-- data=domain=example.com&port=8080&username=xxx&password=&topic=&acc=-1&clientid=
```

```
|-- url=https://example.com:443/acl/
|-- data=domain=example.com&port=8080&username=xxx&password=&topic=abc&acc=2&clientid=mosqpub/6349-mqttkaf001
```

We will be happy if you can accept our's code :)