### PR TITLE
Fix memory leak in caching and don't return expired entry

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -156,11 +156,11 @@ int cache_q(const char *clientid, const char *username, const char *topic, int a
 	if (a) {
 		// printf("---> CACHED! %d\n", a->granted);
 
-		granted = a->granted;
-
 		if (time(NULL) > (a->seconds + cacheseconds)) {
 			_log(DEBUG, " Expired [%s] for (%s,%s,%d)", hex, clientid, username, access);
 			HASH_DEL(ud->aclcache, a);
+		} else {
+			granted = a->granted;
 		}
 	}
 

--- a/cache.c
+++ b/cache.c
@@ -111,6 +111,7 @@ void acl_cache(const char *clientid, const char *username, const char *topic, in
 		if (time(NULL) > (a->seconds + cacheseconds)) {
 			_log(DEBUG, " Expired [%s] for (%s,%s,%d)", hex, clientid, username, access);
 			HASH_DEL(ud->aclcache, a);
+			free(a);
 		}
 	} else {
 		a = (struct aclcache *)malloc(sizeof(struct aclcache));
@@ -130,6 +131,7 @@ void acl_cache(const char *clientid, const char *username, const char *topic, in
 		if (now > (a->seconds + ud->cacheseconds)) {
 			_log(DEBUG, " Cleanup [%s]", a->hex);
 			HASH_DEL(ud->aclcache, a);
+			free(a);
 		}
 	}
 }
@@ -159,6 +161,7 @@ int cache_q(const char *clientid, const char *username, const char *topic, int a
 		if (time(NULL) > (a->seconds + cacheseconds)) {
 			_log(DEBUG, " Expired [%s] for (%s,%s,%d)", hex, clientid, username, access);
 			HASH_DEL(ud->aclcache, a);
+			free(a);
 		} else {
 			granted = a->granted;
 		}


### PR DESCRIPTION
If I correctly understood how caching work, I've found two small bugs:

Memory leak:

HASH_DELETE do not free the aclcache structure, so I've added a call to free() after each HASH_DELETE call.

Expired entry returned:

In cache_q, when an entry is found in hash table, we check if it's expired. If so, we remove it from hash table but also return the expired result. I've modified to only return cached result if not expired.


Does it look correct for you ?