### PR TITLE
Fix memory leak when building the list of headers

### DIFF
--- a/be-http.c
+++ b/be-http.c
@@ -118,8 +118,8 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 		return (FALSE);
 	}
 	if (conf->hostheader != NULL)
-		curl_slist_append(headerlist, conf->hostheader);
-	curl_slist_append(headerlist, "Expect:");
+		headerlist = curl_slist_append(headerlist, conf->hostheader);
+	headerlist = curl_slist_append(headerlist, "Expect:");
 
 	//_log(LOG_NOTICE, "u=%s p=%s t=%s acc=%d", username, password, topic, acc);
 


### PR DESCRIPTION
curl_slist_append returns the new start of the list, which needs to be
stored. Without this, the list elements are lost right away, and the
memory of both the linked list items and strings (as they are copied)
is leaked.