### PR TITLE
Quiet log

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Options therein with a leading ```auth_opt_``` are handed to the plugin. The fol
 | -------------- | ---------- | :---------: | --------------------- |
 | backends       |            |     Y       | comma-separated list of back-ends to load |
 | superusers     |            |             | fnmatch(3) case-sensitive string
+| log_quiet      | false      |             | don't log DEBUG messages |
 
 Individual back-ends have their options described in the sections below.
 

--- a/auth-plug.c
+++ b/auth-plug.c
@@ -146,6 +146,15 @@ int mosquitto_auth_plugin_init(void **userdata, struct mosquitto_auth_opt *auth_
 		}
 		if (!strcmp(o->key, "cacheseconds"))
 			ud->cacheseconds = atol(o->value);
+		if (!strcmp(o->key, "log_quiet")) {
+			if(!strcmp(o->value, "false") || !strcmp(o->value, "0")){
+				log_quiet = 0;
+			}else if(!strcmp(o->value, "true") || !strcmp(o->value, "1")){
+				log_quiet = 1;
+			}else{
+				_log(LOG_NOTICE, "Error: Invalid log_quiet value (%s).", o->value);
+			}
+		}
 #if 0
 		if (!strcmp(o->key, "topic_prefix"))
 			ud->topicprefix = strdup(o->value);

--- a/log.c
+++ b/log.c
@@ -34,11 +34,15 @@
 #include <time.h>
 #include "log.h"
 
+int log_quiet=0;
+
 void _log(int priority, const char *fmt, ...)
 {
 	va_list va;
 	time_t now;
 
+	if (log_quiet && priority <= LOG_DEBUG)
+		return;
 
 	/* FIXME: use new log function when @ralight is ready */
 	/* interim solution - link with -rdynamic then #include <mosquitto_broker.h> and use _mosquitto_log_printf(). */

--- a/log.h
+++ b/log.h
@@ -32,3 +32,5 @@
 
 void _log(int priority, const char *fmt, ...);
 void _fatal(const char *fmt, ...);
+
+extern int log_quiet;


### PR DESCRIPTION
I known that more in-deep review of logging in planned (#9), but in mean time, debug logs are too verbose and may contains password (at least with backend HTTP).

This pull request add an auth_opt to reduce log verbosity. When auth_opt_log_quiet is true, LOG_DEBUG are not longer shown