### PR TITLE
Handle backend downtime in a safer way

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,10 @@ The following `auth_opt_` options are supported by the `http` back-end:
 | http_aclcheck_uri |                   |      Y      | URI for check acl               |
 | http_with_tls     | false             |      N      | Use TLS on connect              |
 
-If the configured URLs return an HTTP status code == `200`, the authentication /
-authorization succeeds, else it fails.
+If the configured URLs return an HTTP status code == `2xx`, the authentication /
+authorization succeeds. If the status code == `4xx` authentication /
+authorization fails. For status code == `5xx` or server unreachable, if no
+other backend succeeded, then an error is returned and client is disconnected.
 
 | URI-Param         | username | password | clientid | topic | acc |
 | ----------------- | -------- | -------- | -------- | :---: | :-: |

--- a/backends.h
+++ b/backends.h
@@ -33,6 +33,9 @@
 #ifndef FALSE
 # define FALSE (0)
 #endif
+#ifndef BACKEND_ERROR
+# define BACKEND_ERROR (2)
+#endif
 
 #ifndef __BACKENDS_H
 # define __BACKENDS_H

--- a/be-http.c
+++ b/be-http.c
@@ -197,11 +197,14 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 		re = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &respCode);
 		if (re == CURLE_OK && respCode >= 200 && respCode < 300) {
 			ok = TRUE;
+		} else if (re == CURLE_OK && respCode >= 500) {
+			ok = BACKEND_ERROR;
 		} else {
 			//_log(LOG_NOTICE, "http auth fail re=%d respCode=%d", re, respCode);
 		}
 	} else {
 		_log(LOG_DEBUG, "http req fail url=%s re=%s", url, curl_easy_strerror(re));
+		ok = BACKEND_ERROR;
 	}
 
 	curl_easy_cleanup(curl);

--- a/be-mysql.c
+++ b/be-mysql.c
@@ -248,16 +248,16 @@ int be_mysql_superuser(void *handle, const char *username)
     if (mysql_ping(conf->mysql)) {
         fprintf(stderr, "%s\n", mysql_error(conf->mysql));
         if (!auto_connect(conf)) {
-            return (FALSE);
+            return (BACKEND_ERROR);
         }
     }
 
 	if ((u = escape(conf, username, &ulen)) == NULL)
-		return (FALSE);
+		return (BACKEND_ERROR);
 
 	if ((query = malloc(strlen(conf->superquery) + ulen + 128)) == NULL) {
 		free(u);
-		return (FALSE);
+		return (BACKEND_ERROR);
 	}
 	sprintf(query, conf->superquery, u);
 	free(u);
@@ -266,6 +266,7 @@ int be_mysql_superuser(void *handle, const char *username)
 
 	if (mysql_query(conf->mysql, query)) {
 		fprintf(stderr, "%s\n", mysql_error(conf->mysql));
+		issuper = BACKEND_ERROR;
 		goto out;
 	}
 
@@ -323,16 +324,16 @@ int be_mysql_aclcheck(void *handle, const char *clientid, const char *username, 
 	if (mysql_ping(conf->mysql)) {
 		fprintf(stderr, "%s\n", mysql_error(conf->mysql));
 		if (!auto_connect(conf)) {
-			return (FALSE);
+			return (BACKEND_ERROR);
 		}
 	}
 
 	if ((u = escape(conf, username, &ulen)) == NULL)
-		return (FALSE);
+		return (BACKEND_ERROR);
 
 	if ((query = malloc(strlen(conf->aclquery) + ulen + 128)) == NULL) {
 		free(u);
-		return (FALSE);
+		return (BACKEND_ERROR);
 	}
 	sprintf(query, conf->aclquery, u, acc);
 	free(u);
@@ -341,6 +342,7 @@ int be_mysql_aclcheck(void *handle, const char *clientid, const char *username, 
 
 	if (mysql_query(conf->mysql, query)) {
 		_log(LOG_NOTICE, "%s", mysql_error(conf->mysql));
+		match = BACKEND_ERROR;
 		goto out;
 	}
 

--- a/be-postgres.c
+++ b/be-postgres.c
@@ -200,6 +200,7 @@ int be_pg_superuser(void *handle, const char *username)
 	if ( PQresultStatus(res) != PGRES_TUPLES_OK )
 	{
 		fprintf(stderr, "%s\n", PQresultErrorMessage(res));
+		issuper = BACKEND_ERROR;
 		goto out;
 	}
 
@@ -266,6 +267,7 @@ int be_pg_aclcheck(void *handle, const char *clientid, const char *username, con
 	if ( PQresultStatus(res) != PGRES_TUPLES_OK )
 	{
 		fprintf(stderr, "%s\n", PQresultErrorMessage(res));
+		match = BACKEND_ERROR;
 		goto out;
 	}
 

--- a/be-redis.c
+++ b/be-redis.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include "log.h"
 #include "hash.h"
+#include "backends.h"
 #include <hiredis/hiredis.h>
 
 struct redis_backend {
@@ -181,7 +182,7 @@ int be_redis_aclcheck(void *handle, const char *clientid, const char *username, 
 	r = redisCommand(conf->redis, query, username, acc);
 	if (r == NULL || conf->redis->err != REDIS_OK) {
 		be_redis_reconnect(conf);
-		return 0;
+		return BACKEND_ERROR;
 	}
 
 	free(query);

--- a/cache.c
+++ b/cache.c
@@ -106,7 +106,7 @@ void acl_cache(const char *clientid, const char *username, const char *topic, in
 
 	HASH_FIND_STR(ud->aclcache, hex, a);
 	if (a) {
-		granted = a->granted;
+		a->granted = granted;
 
 		if (time(NULL) > (a->seconds + cacheseconds)) {
 			_log(LOG_DEBUG, " Expired [%s] for (%s,%s,%d)", hex, clientid, username, access);


### PR DESCRIPTION
This pull request return MOSQ_ERR_UNKNOWN in ACL check when backend are unreachable or broken.

The issue solved is that when your HTTP (or MySQL) backend is down, the current code return MOSQ_DENY_ACL. Which means that : 1) the message is rejected without notification for the sender 2) that rejection is cached for 5 minutes

By returning MOSQ_ERR_UNKNOWN in such case : 
1) the sender is "notified" (it is disconnected)
2) the rejection is not cached.

The new code only return MOSQ_ERR_UNKNOWN if at least one backend was unreachable and no other backend authorized the access.

I've updated backend to return such error when the backend fail due to network error / service down or
due to internal error of that backend. This means for HTTP : 5xx are considered as error and not longer as deny_acl.

I've updated the following backend : 
* MySQL
* HTTP
* PostgresSQL
* Redis

Authentication was not updated, because both MOSQ_ERR_UNKNOWN or MOSQ_DENY_AUTH result in client disconnection and authentication was not cached.