### PR TITLE
Support for MongoDB user authentication

### DIFF
--- a/be-mongo.c
+++ b/be-mongo.c
@@ -1,7 +1,7 @@
 /*
- * Original Work: 
+ * Original Work:
  *      Copyright (c) 2014 zhangxj <zxj_2007_happy@163.com>
- * Modified and Adapted for Mosquitto_auth_plug by: 
+ * Modified and Adapted for Mosquitto_auth_plug by:
  *         Gopalakrishna Palem < http://gk.palem.in/ >
  */
 
@@ -25,18 +25,33 @@ struct mongo_backend {
 void *be_mongo_init()
 {
     struct mongo_backend *conf;
-    char *host, *p;
+    char *host, *p, *user, *password, *authSource;
 
     if ((host = p_stab("mongo_host")) == NULL)
         host = "localhost";
     if ((p = p_stab("mongo_port")) == NULL)
         p = "27017";
+    user = p_stab("mongo_user");
+    password = p_stab("mongo_password");
+    authSource = p_stab("mongo_authSource");
 
      char uristr[128] = {0};
      strcpy(uristr, "mongodb://");
+     if (user != NULL) {
+        strcat(uristr, user);
+        if (password != NULL) {
+           strcat(uristr, ":");
+           strcat(uristr, password);
+        }
+        strcat(uristr, "@");
+     }
      strcat(uristr, host);
      strcat(uristr, ":");
      strcat(uristr, p);
+     if (authSource != NULL) {
+        strcat(uristr, "?authSource=");
+        strcat(uristr, authSource);
+     }
      printf("mongo: [%s]\n", uristr);
 
     conf = (struct mongo_backend *)malloc(sizeof(struct mongo_backend));
@@ -83,9 +98,9 @@ char *be_mongo_getuser(void *handle, const char *username, const char *password,
 
          bson_iter_init(&iter, doc);
          bson_iter_find(&iter, passLoc);
-		 
+
          char *src = (char *)bson_iter_utf8(&iter, NULL);
-		 size_t tmp = strlen(src); 
+		 size_t tmp = strlen(src);
 		 result = (char *) malloc(tmp);
 		 memset(result, 0, tmp);
          memcpy(result, src, tmp);
@@ -101,7 +116,7 @@ char *be_mongo_getuser(void *handle, const char *username, const char *password,
    mongoc_collection_destroy (collection);
    return result;
 }
- 
+
 
 void be_mongo_destroy(void *handle)
 {
@@ -121,7 +136,7 @@ int be_mongo_superuser(void *conf, const char *username)
 	bson_error_t error;
 	const bson_t *doc;
 	int result;
-	
+
 	bson_t query;
 	bson_iter_t iter;
 	bson_init (&query);
@@ -137,17 +152,17 @@ int be_mongo_superuser(void *conf, const char *username)
 									&query,
 									NULL,
 									NULL);
-									
+
 	while (!mongoc_cursor_error (cursor, &error) &&
 			mongoc_cursor_more (cursor)) {
 		if (mongoc_cursor_next (cursor, &doc)) {
 				bson_iter_init(&iter, doc);
 				bson_iter_find(&iter, superUser);
-				
+
 				result = (int64_t) bson_iter_as_int64(&iter);
 
 				//_log(LOG_NOTICE, "SUPERUSER: %d", result);
-				
+
 		}
 	}
 
@@ -192,7 +207,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 									&query,
 									NULL,
 									NULL);
-	
+
 	while (!mongoc_cursor_error (cursor, &error) &&
 			mongoc_cursor_more (cursor)) {
 		if (foundFlag == 0 && mongoc_cursor_next (cursor, &doc)) {
@@ -204,7 +219,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 				bson_destroy(&query);
 				mongoc_cursor_destroy(cursor);
 				mongoc_collection_destroy(collection);
-				
+
 				bson_init(&query);
 				bson_append_int64(&query, topicID, -1, topId);
 				collection = mongoc_client_get_collection(handle->client, dbName, topicLoc);
@@ -215,24 +230,24 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 												0,
 												&query,
 												NULL,
-												NULL);		
+												NULL);
 				foundFlag = 1;
 		}
 		if (foundFlag == 1 && mongoc_cursor_next(cursor, &doc)) {
-				
+
 			bson_iter_init(&iter, doc);
 			bson_iter_find(&iter, topicLoc);
 			uint32_t len;
 			const uint8_t *arr;
 			bson_iter_array(&iter, &len, &arr);
 			bson_t b;
-			
-			
-			
+
+
+
 			if (bson_init_static(&b, arr, len))	{
 				bson_iter_init(&iter, &b);
 				while (bson_iter_next(&iter)) {
-			
+
 					char *str = bson_iter_dup_utf8(&iter, &len);
 
 					mosquitto_topic_matches_sub(str, topic, &check);
@@ -248,20 +263,20 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 		}
 
 	}
-	
+
 
 	if (mongoc_cursor_error (cursor, &error)) {
 			fprintf (stderr, "Cursor Failure: %s\n", error.message);
 			return 0;
 	}
-	
+
 
 	bson_destroy(&query);
 	mongoc_cursor_destroy (cursor);
 	mongoc_collection_destroy(collection);
 
 
-	
+
 
 
 


### PR DESCRIPTION
Added support for MongoDB user authentication by reading mongo_user, mongo_password and mongo_authSource from the configuration and building the uri. The added fields are optional.

For example, using these settings in `mosquitto.conf`:

```
auth_opt_backends mongo
auth_opt_mongo_user mosquitto
auth_opt_mongo_password secret
auth_opt_mongo_authSource users
```

Builds the uri `mongodb://mosquitto:secret@localhost:27017?authSource=users`.