### PR TITLE
Added basic authentication for http

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ The following `auth_opt_` options are supported by the `http` back-end:
 | http_superuser_uri|                   |      Y      | URI for check superuser         |
 | http_aclcheck_uri |                   |      Y      | URI for check acl               |
 | http_with_tls     | false             |      N      | Use TLS on connect              |
+| http_basic_auth_key|                  |      N      | Basic Authentication Key        |
 
 If the configured URLs return an HTTP status code == `2xx`, the authentication /
 authorization succeeds. If the status code == `4xx` authentication /

--- a/be-http.c
+++ b/be-http.c
@@ -118,6 +118,10 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 		headerlist = curl_slist_append(headerlist, conf->hostheader);
 	headerlist = curl_slist_append(headerlist, "Expect:");
 
+	if(conf->basic_auth !=NULL){
+		headerlist = curl_slist_append(headerlist, conf->basic_auth);
+	}
+
 	//_log(LOG_NOTICE, "u=%s p=%s t=%s acc=%d", username, password, topic, acc);
 
 	url = (char *)malloc(strlen(conf->ip) + strlen(uri) + 20);
@@ -262,6 +266,10 @@ void *be_http_init()
 	conf->getuser_envs = p_stab("http_getuser_params");
 	conf->superuser_envs = p_stab("http_superuser_params");
 	conf->aclcheck_envs = p_stab("http_aclcheck_params");
+	if(p_stab("http_basic_auth_key")!= NULL){
+		conf->basic_auth = (char *)malloc( strlen("Authorization: Basic %s") + strlen(p_stab("http_basic_auth_key")));
+		sprintf(conf->basic_auth, "Authorization: Basic %s",p_stab("http_basic_auth_key"));
+	}
 
 	if (p_stab("http_with_tls") != NULL) {
 		conf->with_tls = p_stab("http_with_tls");

--- a/be-http.h
+++ b/be-http.h
@@ -44,6 +44,7 @@ struct http_backend {
 	char *superuser_envs;
 	char *aclcheck_envs;
 	char *with_tls;
+	char *basic_auth;
 };
 
 void *be_http_init();


### PR DESCRIPTION
As there is not authentication for superuser and acl, we have implemented a new feature.
Here we will accept a new configuration to get the basic auth key from mosquitto.conf and if present we will set as authorization header in all post request.

Kindly please review it and merge to master.