### PR TITLE
fixes segmentationfault in *be_mongo_getuser()

### DIFF
--- a/be-mongo.c
+++ b/be-mongo.c
@@ -159,7 +159,7 @@ char *be_mongo_getuser(void *handle, const char *username, const char *password,
 		 size_t tmp = strlen(src);
 		 result = (char *) malloc(tmp);
 		 memset(result, 0, tmp);
-         memcpy(result, src, tmp);
+         memcpy(result, src, tmp + 1);
       }
    }
 


### PR DESCRIPTION
The function memcpy() should be used with (tmp+1), cause without the null character copied, the string ends undefined. This was found, cause sometimes the authentication irregular fails with mongodb backend.