### PR TITLE
Add OpenSSL version conditional around use of EVP_MD_CTX_new/_free

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -45,12 +45,20 @@ static unsigned int sha_hash(const char *data, size_t size, unsigned char *out)
 	const EVP_MD *md = EVP_get_digestbyname("SHA1");
 
 	if (md != NULL) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000
+		EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
+#else
 		EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+#endif
 		EVP_MD_CTX_init(mdctx);
 		EVP_DigestInit_ex(mdctx, md, NULL);
 		EVP_DigestUpdate(mdctx, data, size);
 		EVP_DigestFinal_ex(mdctx, out, &md_len);
+#if OPENSSL_VERSION_NUMBER < 0x10100000
+		EVP_MD_CTX_destroy(mdctx);
+#else
 		EVP_MD_CTX_free(mdctx);
+#endif
 	}
 	return md_len;
 }


### PR DESCRIPTION
> EVP_MD_CTX_new() and EVP_MD_CTX_free() in OpenSSL 1.1.

This patch permits compilation on RHEL7 systems (that have
OpenSSL tagged as 1.0)