### PR TITLE
mongo backend fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ ifneq ($(BACKEND_MONGO), no)
 	BE_CFLAGS += -I/usr/local/include/
 	BE_CFLAGS += -I/usr/local/include/libmongoc-1.0/
 	BE_CFLAGS += -I/usr/local/include/libbson-1.0/
+	BE_CFLAGS += -Wno-deprecated-declarations
 	BE_LDFLAGS += -L/usr/local/lib
 	BE_LDADD += -lmongoc-1.0 -lbson-1.0
 	OBJS += be-mongo.o

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -273,7 +273,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
             bson_iter_find(&iter, handle->topic_loc);
             //http://mongoc.org/libbson/1.0.2/bson_oid_t.html
             //topId = (int64_t) bson_iter_as_int64(&iter);//, NULL);
-            topId = (bson_oid_t) bson_iter_oid(&iter);//, NULL);
+            topId = bson_iter_oid(&iter);//, NULL);
             foundFlag = true;
     }
 	

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -247,7 +247,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 	bson_iter_t iter;
 
 	bool check = false, foundFlag = false;
-	int match = 0;
+	int match = 0, topId = 0; 
 
 	bson_t query;
 

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -247,7 +247,8 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 	bson_iter_t iter;
 
 	bool check = false, foundFlag = false;
-	int match = 0, topId = 0; 
+	int match = 0; 
+    bson_oid_t *topId; 
 
 	bson_t query;
 
@@ -288,7 +289,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 
     if (foundFlag) {
         bson_init(&query);
-        bson_append_oid(&query, handle->topicId_loc, -1, topId);
+        bson_append_oid(&query, handle->topicId_loc, -1, &topId);
         collection = mongoc_client_get_collection(handle->client, handle->database, handle->topics_coll);
         cursor = mongoc_collection_find(collection,
                                         MONGOC_QUERY_NONE,

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -289,7 +289,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 
     if (foundFlag) {
         bson_init(&query);
-        bson_append_oid(&query, handle->topicId_loc, -1, &topId);
+        bson_append_oid(&query, handle->topicId_loc, -1, topId);
         collection = mongoc_client_get_collection(handle->client, handle->database, handle->topics_coll);
         cursor = mongoc_collection_find(collection,
                                         MONGOC_QUERY_NONE,

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -248,7 +248,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 
 	bool check = false, foundFlag = false;
 	int match = 0; 
-    bson_oid_t *topId; 
+    const bson_oid_t *topId; 
 
 	bson_t query;
 

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -270,8 +270,9 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 
             bson_iter_init(&iter, doc);
             bson_iter_find(&iter, handle->topic_loc);
-
-            topId = (int64_t) bson_iter_as_int64(&iter);//, NULL);
+            //http://mongoc.org/libbson/1.0.2/bson_oid_t.html
+            //topId = (int64_t) bson_iter_as_int64(&iter);//, NULL);
+            topId = (bson_oid_t) bson_iter_oid(&iter);//, NULL);
             foundFlag = true;
     }
 	
@@ -287,7 +288,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 
     if (foundFlag) {
         bson_init(&query);
-        bson_append_int64(&query, handle->topicId_loc, -1, topId);
+        bson_append_oid(&query, handle->topicId_loc, -1, topId);
         collection = mongoc_client_get_collection(handle->client, handle->database, handle->topics_coll);
         cursor = mongoc_collection_find(collection,
                                         MONGOC_QUERY_NONE,


### PR DESCRIPTION
### Mongo backend was not working due the following reasons:

#### 1. wrong usage of `mongoc_cursor_more` causing infinite loops under certain conditions

  - at least for `mongo-c-driver` version >= 1.3.1
  - as it is explained here: [https://jira.mongodb.org/browse/CDRIVER-708](https://jira.mongodb.org/browse/CDRIVER-708)

Solved removing the loops through the recordsets (since each query is expected to return 0 or 1 records) and getting rid of the check `mongoc_cursor_more`.


#### 2. `mongoc_collection_find` is deprecated as of `mongo-c-driver` versions > 1.3.1

Solved adding a `-Wno-deprecated-declarations` flag if building for mongo backend, to preserve compatibility with previous `mongo-c-driver`.

