### PR TITLE
If no host or port are specified, revert to libpq to determine how to…

### DIFF
--- a/be-postgres.c
+++ b/be-postgres.c
@@ -65,8 +65,8 @@ void *be_pg_init()
 	pass   = p_stab("pass");
 	dbname = p_stab("dbname");
 
-	host = (host) ? host : strdup("localhost");
-	port = (p) ? p : strdup("5432");
+	host = (host) ? host : strdup("");
+	port = (p) ? p : strdup("");
 
 	userquery = p_stab("userquery");
 


### PR DESCRIPTION
… connect to the database.
This may involve reading configuration files such as .pgpass, or getting it from environment variables.

This fixes #199 .
