### PR TITLE
[mongo] Don't segfault on missing fields, allow oid|utf8|int for topics pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,12 +521,12 @@ The `mongo` back-end works with superuser and ACL checks with the following coll
 users = {
          username: "user",
 	     password: "PBKDF_string"
-	     topics: int (topicID location)
-	     superuser: int (1 true, 0 false)
+	     topics: int | oid | string (reference to a document in collection_topics)
+	     superuser: int | boolean (optional, superuser if truthy)
         }
 
 topics = {
-           _id: int,
+           _id: int | oid | string (as referenced by users.topics),
 		   topics: ["xx/xx/#", "yy/#", ...]
 		 }
 ```
@@ -545,7 +545,7 @@ The following `auth_opt_mongo_` options are supported by the mongo back-end:
 | collection_topics  | topics            | Collection for Topic Documents
 | location_password  | password          | Password field name in User Document
 | location_topic     | topics            | Topic Document pointer field name in User Document
-| location_topicId  | _id               | Field name that location_topic points to in Topic Document
+| location_topicId   | _id               | Field name that location_topic points to in Topic Document
 | location_superuser | superuser         | Superuser field name in User Document
 
 Mosquitto configuration for the `mongo` back-end:


### PR DESCRIPTION
A few minor improvements to the mongo backend mostly around resilience.

* Don't segfault on improperly formatted documents (missing `user.[location_superuser]` property, missing `user.[location_topicId]` property, missing `topic.topics` list in topics document.
* Allow `user.[location_topicId]` to be an int, a string, or a ObjectID. This fixes a breaking change introduced by https://github.com/jpmens/mosquitto-auth-plug/commit/fff09583f0215c442baad2ea54f5e8d13c5be8a8 where `user.[location_topicId]` switched from needing to be an int to needing to be an ObjectID.
* Allow `user.[location_superuser]` to be unset, in which case it is treated as false. If set, allow any type which can be case to a boolean.