### PR TITLE
[mongo] Support ACL maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,9 +550,9 @@ If the user document references a separate topics document, that document should
 
 #### ACL format
 
-Topics may be given as either an array of topic strings, eg `["topic1/#", "topic2/?"]`, in which case all topics will 
+Topics may be given as either an array of topic strings, eg `["topic1/#", "topic2/+"]`, in which case all topics will 
 be read-write, or as a sub-document mapping topic names to the strings `"r"`, `"w"`, `"rw"`, eg 
-`{ "article/#":"r", "article/?/comments":"rw", "ballotbox":"w" }`.
+`{ "article/#":"r", "article/+/comments":"rw", "ballotbox":"w" }`.
 
 #### Configuration
 

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ You may use any combination of these options; authorisation will be granted if a
     username: string,
     [location_password]: string, // A PBKDF2 hash, see 'Passwords' section
     [location_topics]: int | oid | string, // reference to a document in collection_topics)
-    [user_embedded_topics_prop]: string[], // optional list of permitted topics eg ["xx/xx/#", "yy/#", ...]
+    [user_embedded_topics_prop]: string[] | { [topic: string]: "r"|"w"|"rw" }, // see 'ACL format'
     [location_superuser]: int | boolean // optional, superuser if truthy
 }
 ```
@@ -544,9 +544,15 @@ If the user document references a separate topics document, that document should
 ```
 {
     [location_topicId]: int | oid | string, // unique id, as referenced by users[location_topics],
-    [location_topics]: string[] // topics with full access eg ["xx/xx/#", "yy/#", ...]
+    [location_topics]: string[] | { [topic: string]: "r"|"w"|"rw" } // see 'ACL format'
 }
 ```
+
+#### ACL format
+
+Topics may be given as either an array of topic strings, eg `["topic1/#", "topic2/?"]`, in which case all topics will 
+be read-write, or as a sub-document mapping topic names to the strings `"r"`, `"w"`, `"rw"`, eg 
+`{ "article/#":"r", "article/?/comments":"rw", "ballotbox":"w" }`.
 
 #### Configuration
 
@@ -574,8 +580,6 @@ auth_plugin /home/jpm/mosquitto-auth-plug/auth-plug.so
 auth_opt_mongo_host localhost
 auth_opt_mongo_port 27017
 ```
-currently no readwrite checks on ACL, all topics will be readwrite, do not add a flag to the array of topics in db.
-
 
 ## Passwords
 

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -151,7 +151,7 @@ char *be_mongo_getuser(void *handle, const char *username, const char *password,
 
 		bson_iter_init(&iter, doc);
 		if (bson_iter_find(&iter, conf->password_loc)) {
-			char *password_src = (char *)bson_iter_utf8(&iter, NULL);
+			const char *password_src = bson_iter_utf8(&iter, NULL);
 			size_t password_len = strlen(password_src) + 1;
 			result = (char *) malloc(password_len);
 			memcpy(result, password_src, password_len);
@@ -274,9 +274,9 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 			if (loc_id_type == BSON_TYPE_OID) {
 				topic_lookup_oid = bson_iter_oid(&iter);
 			} else if (loc_id_type == BSON_TYPE_INT32 || loc_id_type == BSON_TYPE_INT64) {
-				topic_lookup_int64 = (int64_t)bson_iter_as_int64(&iter);
+				topic_lookup_int64 = bson_iter_as_int64(&iter);
 			} else if (loc_id_type == BSON_TYPE_UTF8) {
-				topic_lookup_utf8 = (const char *)bson_iter_utf8(&iter, NULL);
+				topic_lookup_utf8 = bson_iter_utf8(&iter, NULL);
 			}
 		}
 	}

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -193,6 +193,7 @@ void be_mongo_destroy(void *handle)
 		free(conf->topic_loc);
 		free(conf->topicId_loc);
 		free(conf->superuser_loc);
+		free(conf->user_embedded_topics_prop);
 
 		mongoc_client_destroy(conf->client);
 		conf->client = NULL;

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -27,14 +27,17 @@ struct mongo_backend {
 	char *topic_loc;
 	char *topicId_loc;
 	char *superuser_loc;
+	char *user_embedded_topics_prop;
 };
+
+bool check_acl_topics_array(const bson_iter_t *topics, const char *req_topic);
 
 void *be_mongo_init()
 {
 	struct mongo_backend *conf;
 	char *host, *p, *user, *password, *authSource;
 	char *database, *users_coll, *topics_coll, *password_loc, *topic_loc;
-	char *topicId_loc, *superuser_loc;
+	char *topicId_loc, *superuser_loc, *user_embedded_topics_prop;
 
 	conf = (struct mongo_backend *)malloc(sizeof(struct mongo_backend));
 
@@ -74,6 +77,12 @@ void *be_mongo_init()
 		conf->topic_loc = "topics";
 	} else {
 		conf->topic_loc = topic_loc;
+	}
+
+	if ((user_embedded_topics_prop = p_stab("mongo_user_embedded_topics_prop")) == NULL) {
+		conf->user_embedded_topics_prop = "topics";
+	} else {
+		conf->user_embedded_topics_prop = user_embedded_topics_prop;
 	}
 
 	if ((topicId_loc = p_stab("mongo_location_topicId")) == NULL) {
@@ -242,9 +251,6 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 	bson_error_t error;
 	const bson_t *doc;
 	bson_iter_t iter;
-	bson_type_t loc_id_type;
-
-	bool check = false;
 	int match = 0;
 	const bson_oid_t *topic_lookup_oid = NULL;
 	const char *topic_lookup_utf8 = NULL;
@@ -267,16 +273,23 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 							NULL);
 
 	if (!mongoc_cursor_error (cursor, &error) && mongoc_cursor_next (cursor, &doc)) {
-
-		bson_iter_init(&iter, doc);
-		if (bson_iter_find(&iter, handle->topic_loc)) {
-			loc_id_type = bson_iter_type(&iter);
+		// First find any user[handle->topic_loc]
+		if (bson_iter_init_find(&iter, doc, handle->topic_loc)) {
+			bson_type_t loc_id_type = bson_iter_type(&iter);
 			if (loc_id_type == BSON_TYPE_OID) {
 				topic_lookup_oid = bson_iter_oid(&iter);
 			} else if (loc_id_type == BSON_TYPE_INT32 || loc_id_type == BSON_TYPE_INT64) {
 				topic_lookup_int64 = bson_iter_as_int64(&iter);
 			} else if (loc_id_type == BSON_TYPE_UTF8) {
 				topic_lookup_utf8 = bson_iter_utf8(&iter, NULL);
+			}
+		}
+
+		// Look through the props from the beginning for user[handle->user_embedded_topics_prop]
+		if (bson_iter_init_find(&iter, doc, handle->user_embedded_topics_prop)) {
+			bson_type_t embedded_prop_type = bson_iter_type(&iter);
+			if (embedded_prop_type == BSON_TYPE_ARRAY) {
+				match = check_acl_topics_array(&iter, topic);
 			}
 		}
 	}
@@ -289,7 +302,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 	mongoc_cursor_destroy (cursor);
 	mongoc_collection_destroy(collection);
 
-	if (topic_lookup_oid != NULL || topic_lookup_int64 != 0 || topic_lookup_utf8 != NULL) {
+	if (!match && (topic_lookup_oid != NULL || topic_lookup_int64 != 0 || topic_lookup_utf8 != NULL)) {
 		bson_init(&query);
 		if (topic_lookup_oid != NULL) {
 			bson_append_oid(&query, handle->topicId_loc, -1, topic_lookup_oid);
@@ -313,21 +326,9 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 
 			bson_iter_init(&iter, doc);
 			if (bson_iter_find(&iter, handle->topic_loc)) {
-				uint32_t len;
-				const uint8_t *arr;
-				bson_iter_array(&iter, &len, &arr);
-				bson_t b;
-
-				if (bson_init_static(&b, arr, len)) {
-					bson_iter_init(&iter, &b);
-					while (bson_iter_next(&iter)) {
-						const char *str = bson_iter_utf8(&iter, NULL);
-						mosquitto_topic_matches_sub(str, topic, &check);
-						if (check) {
-							match = 1;
-							break;
-						}
-					}
+				bson_type_t loc_prop_type = bson_iter_type(&iter);
+				if (loc_prop_type == BSON_TYPE_ARRAY) {
+					match = check_acl_topics_array(&iter, topic);
 				}
 			} else {
 				_log(LOG_NOTICE, "[mongo] ACL check error - no topic list found for user (%s) in collection (%s)", username, handle->topics_coll);
@@ -341,10 +342,27 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 		bson_destroy(&query);
 		mongoc_cursor_destroy(cursor);
 		mongoc_collection_destroy(collection);
-	} else {
-		_log(LOG_NOTICE, "[mongo] ACL check error - user (%s) does not have a topic list", username);
 	}
 
 	return match;
 }
+
+// Check an embedded array of the form [ "public/#", "private/myid/#" ]
+bool check_acl_topics_array(const bson_iter_t *topics, const char *req_topic)
+{
+	bson_iter_t iter;
+	bson_iter_recurse(topics, &iter);
+
+	while (bson_iter_next(&iter)) {
+		const char *permitted_topic = bson_iter_utf8(&iter, NULL);
+		bool topic_matches = false;
+
+		mosquitto_topic_matches_sub(permitted_topic, req_topic, &topic_matches);
+		if (topic_matches) {
+			return true;
+		}
+	}
+	return false;
+}
+
 #endif /* BE_MONGO */

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -371,7 +371,7 @@ bool check_acl_topics_array(const bson_iter_t *topics, const char *req_topic)
 	return false;
 }
 
-// Check an embedded document of the form { "article/#": "r", "article/?/comments": "rw", "ballotbox": "w" }
+// Check an embedded document of the form { "article/#": "r", "article/+/comments": "rw", "ballotbox": "w" }
 bool check_acl_topics_map(const bson_iter_t *topics, const char *req_topic, int req_access)
 {
 	bson_iter_t iter;


### PR DESCRIPTION
Builds on https://github.com/jpmens/mosquitto-auth-plug/pull/210. Add support for r/w/rw topics with a mongo backend via sub-document 'maps' of the form `{ [topic: string]: "r"|"w"|"rw" }`.

(Let me know if a different API would be preferred - I did consider `"readTopics": ["t1","t2"], "writeTopics": ["t3","t4"]` etc which is marginally more space-efficient but IMO isn't as neat, and introduces more config options.)