### PR TITLE
[mongo] Replace deprecated calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,6 @@ ifneq ($(BACKEND_MONGO), no)
 	BE_CFLAGS += -I/usr/local/include/
 	BE_CFLAGS += -I/usr/local/include/libmongoc-1.0/
 	BE_CFLAGS += -I/usr/local/include/libbson-1.0/
-	BE_CFLAGS += -Wno-deprecated-declarations
 	BE_LDFLAGS += -L/usr/local/lib
 	BE_LDADD += -lmongoc-1.0 -lbson-1.0
 	OBJS += be-mongo.o

--- a/be-mongo.c
+++ b/be-mongo.c
@@ -129,14 +129,7 @@ char *be_mongo_getuser(void *handle, const char *username, const char *password,
 	bson_append_utf8 (&query, conf->user_username_prop, -1, username, -1);
 
 	collection = mongoc_client_get_collection (conf->client, conf->database, conf->user_coll);
-	cursor = mongoc_collection_find(collection,
-							MONGOC_QUERY_NONE,
-							0,
-							0,
-							0,
-							&query,
-							NULL,  /* Fields, NULL for all. */
-							NULL); /* Read Prefs, NULL for default */
+	cursor = mongoc_collection_find_with_opts(collection, &query, NULL, NULL);
 
 	if (!mongoc_cursor_error (cursor, &error) &&
 		mongoc_cursor_next (cursor, &doc)) {
@@ -202,14 +195,7 @@ int be_mongo_superuser(void *conf, const char *username)
 
 	collection = mongoc_client_get_collection(handle->client, handle->database, handle->user_coll);
 
-	cursor = mongoc_collection_find(collection,
-							MONGOC_QUERY_NONE,
-							0,
-							0,
-							0,
-							&query,
-							NULL,
-							NULL);
+	cursor = mongoc_collection_find_with_opts(collection, &query, NULL, NULL);
 
 	if (!mongoc_cursor_error (cursor, &error) &&
 		mongoc_cursor_next (cursor, &doc)) {
@@ -250,14 +236,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 
 	collection = mongoc_client_get_collection(handle->client, handle->database, handle->user_coll);
 
-	cursor = mongoc_collection_find(collection,
-							MONGOC_QUERY_NONE,
-							0,
-							0,
-							0,
-							&query,
-							NULL,
-							NULL);
+	cursor = mongoc_collection_find_with_opts(collection, &query, NULL, NULL);
 
 	if (!mongoc_cursor_error (cursor, &error) && mongoc_cursor_next (cursor, &doc)) {
 		// First find any user[handle->user_topiclist_fk_prop]
@@ -301,14 +280,7 @@ int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, co
 			bson_append_utf8(&query, handle->topiclist_key_prop, -1, topic_lookup_utf8, -1);
 		}
 		collection = mongoc_client_get_collection(handle->client, handle->database, handle->topiclist_coll);
-		cursor = mongoc_collection_find(collection,
-								MONGOC_QUERY_NONE,
-								0,
-								0,
-								0,
-								&query,
-								NULL,
-								NULL);
+		cursor = mongoc_collection_find_with_opts(collection, &query, NULL, NULL);
 
 
 		if (!mongoc_cursor_error (cursor, &error) && mongoc_cursor_next(cursor, &doc)) {


### PR DESCRIPTION
Since we already require mongo-c-driver >= 1.4.0 we can remove replace these functions deprecated in 1.3.0 and re-enable`no-deprecated-declarations`.