### PR TITLE
Allow config to add flags to CFLAGS via CFG_CFLAGS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,12 +101,15 @@ endif
 OSSLINC = -I$(OPENSSLDIR)/include
 OSSLIBS = -L$(OPENSSLDIR)/lib -lcrypto
 
-CFLAGS = -I$(MOSQUITTO_SRC)/src/
+CFLAGS := $(CFG_CFLAGS)
+CFLAGS += -I$(MOSQUITTO_SRC)/src/
 CFLAGS += -I$(MOSQUITTO_SRC)/lib/
 ifneq ($(OS),Windows_NT)
 	CFLAGS += -fPIC -Wall -Werror
 endif
 CFLAGS += $(BACKENDS) $(BE_CFLAGS) -I$(MOSQ)/src -DDEBUG=1 $(OSSLINC)
+
+LDFLAGS := $(CFG_LDFLAGS)
 LDFLAGS += $(BE_LDFLAGS) -L$(MOSQUITTO_SRC)/lib/
 # LDFLAGS += -Wl,-rpath,$(../../../../pubgit/MQTT/mosquitto/lib) -lc
 # LDFLAGS += -export-dynamic

--- a/config.mk.in
+++ b/config.mk.in
@@ -15,5 +15,6 @@ MOSQUITTO_SRC =
 # Specify the path the OpenSSL here
 OPENSSLDIR = /usr
 
-# Specify optional/additional linker flags here
-LDFLAGS =
+# Specify optional/additional linker/compiler flags here
+CFG_LDFLAGS =
+CFG_CFLAGS =


### PR DESCRIPTION
Use of additional config variable to guard against default CFLAGS settings from make.
Change handling of LDFLAGS to work like CFLAGS.

This will allow to configure a compilation with debug flag, for example.