### PR TITLE
Add authentication cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ The following `auth_opt_` options are supported by the mysql back-end:
 | mysql_opt_reconnect | true         |             | enable MYSQL_OPT_RECONNECT option
 | mysql_auto_connect  | true         |             | enable auto_connect function
 | anonusername   | anonymous         |             | username to use for anonymous connections
-| cacheseconds   | 300               |             | number of seconds to cache ACL lookups. 0 disables
+| cacheseconds   |                   |             | Deprecated. Alias for acl_cacheseconds
+| acl_cacheseconds  | 300               |             | number of seconds to cache ACL lookups. 0 disables
+| auth_cacheseconds | 0                 |             | number of seconds to cache AUTH lookups. 0 disables
 
 The SQL query for looking up a user's password hash is mandatory. The query
 MUST return a single row only (any other number of rows is considered to be

--- a/auth-plug.c
+++ b/auth-plug.c
@@ -126,8 +126,10 @@ int mosquitto_auth_plugin_init(void **userdata, struct mosquitto_auth_opt *auth_
 	ud->superusers	= NULL;
 	ud->fallback_be = -1;
 	ud->anonusername = strdup("anonymous");
-	ud->cacheseconds = 300;
+	ud->acl_cacheseconds = 300;
+	ud->auth_cacheseconds = 0;
 	ud->aclcache = NULL;
+	ud->authcache = NULL;
 
 	/*
 	 * Shove all options Mosquitto gives the plugin into a hash,
@@ -146,8 +148,10 @@ int mosquitto_auth_plugin_init(void **userdata, struct mosquitto_auth_opt *auth_
 			free(ud->anonusername);
 			ud->anonusername = strdup(o->value);
 		}
-		if (!strcmp(o->key, "cacheseconds"))
-			ud->cacheseconds = atol(o->value);
+		if (!strcmp(o->key, "cacheseconds") || !strcmp(o->key, "acl_cacheseconds"))
+			ud->acl_cacheseconds = atol(o->value);
+		if (!strcmp(o->key, "auth_cacheseconds"))
+			ud->auth_cacheseconds = atol(o->value);
 		if (!strcmp(o->key, "log_quiet")) {
 			if(!strcmp(o->value, "false") || !strcmp(o->value, "0")){
 				log_quiet = 0;
@@ -415,10 +419,19 @@ int mosquitto_auth_plugin_cleanup(void *userdata, struct mosquitto_auth_opt *aut
 	if (ud->anonusername)
 		free(ud->anonusername);
 	if (ud->aclcache != NULL) {
-		struct aclcache *a, *tmp;
+		struct cacheentry *a, *tmp;
 
 		HASH_ITER(hh, ud->aclcache, a, tmp) {
 			HASH_DEL(ud->aclcache, a);
+			free(a);
+		}
+	}
+
+	if (ud->authcache != NULL) {
+		struct cacheentry *a, *tmp;
+
+		HASH_ITER(hh, ud->authcache, a, tmp) {
+			HASH_DEL(ud->authcache, a);
 			free(a);
 		}
 	}
@@ -456,12 +469,19 @@ int mosquitto_auth_unpwd_check(void *userdata, const char *username, const char 
 	struct userdata *ud = (struct userdata *)userdata;
 	struct backend_p **bep;
 	char *phash = NULL, *backend_name = NULL;
-	int match, authenticated = FALSE, nord;
+	int match, authenticated = FALSE, nord, granted;
 
 	if (!username || !*username || !password || !*password)
 		return MOSQ_DENY_AUTH;
 
 	_log(LOG_DEBUG, "mosquitto_auth_unpwd_check(%s)", (username) ? username : "<nil>");
+
+	granted = auth_cache_q(username, password, userdata);
+	if (granted != MOSQ_ERR_UNKNOWN) {
+		_log(LOG_DEBUG, "getuser(%s) CACHEDAUTH: %d",
+			username, (granted == MOSQ_ERR_SUCCESS) ? TRUE : FALSE);
+		return granted;
+	}
 
 	for (nord = 0, bep = ud->be_list; bep && *bep; bep++, nord++) {
 		struct backend_p *b = *bep;
@@ -500,7 +520,9 @@ int mosquitto_auth_unpwd_check(void *userdata, const char *username, const char 
 		free(phash);
 	}
 
-	return (authenticated) ? MOSQ_ERR_SUCCESS : MOSQ_DENY_AUTH;
+	granted = (authenticated) ? MOSQ_ERR_SUCCESS : MOSQ_DENY_AUTH;
+	auth_cache(username, password, granted, userdata);
+	return granted;
 }
 
 int mosquitto_auth_acl_check(void *userdata, const char *clientid, const char *username, const char *topic, int access)
@@ -522,7 +544,7 @@ int mosquitto_auth_acl_check(void *userdata, const char *clientid, const char *u
 		access == MOSQ_ACL_READ ? "MOSQ_ACL_READ" : "MOSQ_ACL_WRITE" );
 
 
-	granted = cache_q(clientid, username, topic, access, userdata);
+	granted = acl_cache_q(clientid, username, topic, access, userdata);
 	if (granted != MOSQ_ERR_UNKNOWN) {
 		_log(LOG_DEBUG, "aclcheck(%s, %s, %d) CACHEDAUTH: %d",
 			username, topic, access, granted);

--- a/cache.h
+++ b/cache.h
@@ -34,7 +34,7 @@
 #ifndef __CACHE_H
 # define __CACHE_H
 
-struct aclcache {
+struct cacheentry {
         char hex[SHA_DIGEST_LENGTH * 2 + 1];    /* key within struct */
         int granted;
         time_t seconds;
@@ -42,6 +42,9 @@ struct aclcache {
 };
 
 void acl_cache(const char *clientid, const char *username, const char *topic, int access, int granted, void *userdata);
-int cache_q(const char *clientid, const char *username, const char *topic, int access, void *userdata);
+int acl_cache_q(const char *clientid, const char *username, const char *topic, int access, void *userdata);
+
+void auth_cache(const char *username, const char *password, int granted, void *userdata);
+int auth_cache_q(const char *username, const char *password, void *userdata);
 
 #endif

--- a/userdata.h
+++ b/userdata.h
@@ -39,8 +39,10 @@ struct userdata {
 	char *superusers;		/* Static glob list */
 	int fallback_be;		/* Backend to use for anonymous connections */
 	char *anonusername;		/* Configured name of anonymous MQTT user */
-	time_t cacheseconds;		/* number of seconds to cache ACL lookups */
-	struct aclcache *aclcache;
+	time_t acl_cacheseconds;		/* number of seconds to cache ACL lookups */
+	struct cacheentry *aclcache;
+	time_t auth_cacheseconds;		/* number of seconds to cache AUTH lookups */
+	struct cacheentry *authcache;
 };
 
 #endif


### PR DESCRIPTION
This PR add an authentication cache and fix #190.
Unlike #90, it does not touch the ACL cache (clientid is kept in the ACL cache).

As asked by #190, the both cache are configurable independently. By default the authentication cache is disabled (auth_cacheseconds = 0) to keep old behavior.