### PR TITLE
Fix double-free

### DIFF
--- a/auth-plug.c
+++ b/auth-plug.c
@@ -429,7 +429,6 @@ int mosquitto_auth_plugin_cleanup(void *userdata, struct mosquitto_auth_opt *aut
 		for (bep = ud->be_list; bep && *bep; bep++) {
 			(*bep)->kill((*bep)->conf);
 			free((*bep)->name);
-			free((*bep)->conf);
 			free(*bep);
 		}
 		free(ud->be_list);

--- a/be-cdb.c
+++ b/be-cdb.c
@@ -80,6 +80,7 @@ void be_cdb_destroy(void *handle)
 	if (conf) {
 		cdb_free(conf->cdb);
 		free(conf->cdbname);
+		free(conf);
 	}
 }
 

--- a/be-redis.c
+++ b/be-redis.c
@@ -132,6 +132,7 @@ void be_redis_destroy(void *handle)
 	if (conf != NULL) {
 		redisFree(conf->redis);
 		conf->redis = NULL;
+		free(conf);
 	}
 }
 


### PR DESCRIPTION
Fix a double free on mosquitto shutdown:
```
1495109810: mosquitto version 1.4.10 terminating                                                                     
1495109810: Saving in-memory database to /var/lib/mosquitto/mosquitto.db.                                            
*** Error in `/usr/sbin/mosquitto': double free or corruption (fasttop): 0x0000000002216f50 ***                       
======= Backtrace: =========                                                                                          
/lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f8f6b46e7e5]                                                             
/lib/x86_64-linux-gnu/libc.so.6(+0x7fe0a)[0x7f8f6b476e0a]                                                             
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f8f6b47a98c]                                                           
/usr/lib/mosquitto/auth-plug.so(mosquitto_auth_plugin_cleanup+0x34f)[0x7f8f6a76aea0]                                  
/usr/sbin/mosquitto[0x4165a4]                                                                                           
/usr/sbin/mosquitto[0x404e07]                                                                                           
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f8f6b417830]                                                 
/usr/sbin/mosquitto[0x404ea9]                                                                                           
======= Memory map: ========                                                                                           
00400000-00426000 r-xp 00000000 00:75 25                                 /usr/sbin/mosquitto                           
00625000-00626000 r--p 00025000 00:75 25                                 /usr/sbin/mosquitto                              
[...]
```

It was due to free((*bep)->conf); done during mosquitto_auth_plugin_cleanup which is already done by most backend during (*bep)->kill(...) (a.k.a. be_XXX_destroy)

Only two backend didn't freed config during be_XXX_destroy: Redis and CDB.

I've added the free(conf) on those two backend and removed the general one.