### PR TITLE
Fix build of be-postgres

### DIFF
--- a/be-postgres.c
+++ b/be-postgres.c
@@ -185,9 +185,8 @@ int be_pg_superuser(void *handle, const char *username)
 	if (!conf || !conf->superquery || !username || !*username)
 		return (FALSE);
 
-	//query for postgres
-		$1 instead of % s
-		const char *values[1] = {username};
+	//query for postgres $1 instead of % s
+	const char *values[1] = {username};
 	int lengths[1] = {strlen(username)};
 	int binary[1] = {0};
 
@@ -225,9 +224,11 @@ out:
  * desired type of access: read/write for subscriptions (READ) (1) for
  * publish (WRITE) (2)
  * 
- * SELECT topic FROM table WHERE username = '%s' AND (acc & %d)		//
- * may user SUB or PUB topic? SELECT topic FROM table WHERE username = '%s'
- * / ignore ACC
+ * SELECT topic FROM table WHERE username = '%s' AND (acc & %d)
+ * may user SUB or PUB topic?
+ *
+ * SELECT topic FROM table WHERE username = '%s'
+ * ignore ACC
  */
 
 int be_pg_aclcheck(void *handle, const char *clientid, const char *username, const char *topic, int acc)
@@ -245,9 +246,8 @@ int be_pg_aclcheck(void *handle, const char *clientid, const char *username, con
 		return (FALSE);
 
 	const int buflen = 11;
-	//10 for 2
-		^32 + 1
-			char accbuffer[buflen];
+	//10 for 2^32 + 1
+	char accbuffer[buflen];
 	snprintf(accbuffer, buflen, "%d", acc);
 
 	const char *values[2] = {username, accbuffer};


### PR DESCRIPTION
Latest commit on master (1ac1ce8) broke compilation of be-postgresql:
```
be-postgres.c: In function 'be_pg_superuser':
be-postgres.c:189:3: error: unknown type name '$1'
   $1 instead of % s
   ^
be-postgres.c:189:14: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'of'
   $1 instead of % s
              ^
be-postgres.c:194:60: error: 'values' undeclared (first use in this function)
  res = PQexecParams(conf->conn, conf->superquery, 1, NULL, values, lengths, binary, 0);
                                                            ^
be-postgres.c:194:60: note: each undeclared identifier is reported only once for each function it appears in
be-postgres.c: In function 'be_pg_aclcheck':
be-postgres.c:249:3: error: expected expression before '^' token
   ^32 + 1
   ^
be-postgres.c:251:11: error: 'accbuffer' undeclared (first use in this function)
  snprintf(accbuffer, buflen, "%d", acc);
           ^
<builtin>: recipe for target 'be-postgres.o' failed

```

The PR fix the compilation of be-postgresql. (nothing but compilation tested, I don't use this backend) 