### PR TITLE
Also use LDFLAGS when compiling and linking np 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ be-mongo.o: be-mongo.c be-mongo.h Makefile
 be-files.o: be-files.c be-files.h Makefile
 
 np: np.c base64.o
-	$(CC) $(CFLAGS) $^ -o $@ $(OSSLIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@ $(OSSLIBS)
 
 $(CDBLIB):
 	(cd $(CDBDIR); make libcdb.a cdb )


### PR DESCRIPTION
So we can link on macOS against libcrypto in brew using this in config.mk:

```bash
# Specify the path to the Mosquitto sources here
MOSQUITTO_SRC = /usr/local/Cellar/mosquitto/1.4.12

# Specify the path the OpenSSL here
OPENSSLDIR = /usr

# Specify optional/additional linker/compiler flags here
# On macOS, add 
#	CFG_LDFLAGS = -undefined dynamic_lookup
# as described in https://github.com/eclipse/mosquitto/issues/244
CFG_LDFLAGS = -undefined dynamic_lookup  -L/usr/local/Cellar/openssl/1.0.2l/lib
CFG_CFLAGS = -I/usr/local/Cellar/openssl/1.0.2l/include -I/usr/local/Cellar/mosquitto/1.4.12/include