### PR TITLE
Add readme instructing to use -DRAWSALT program will not work otherwise

### DIFF
--- a/contrib/C#/README.md
+++ b/contrib/C#/README.md
@@ -1,0 +1,24 @@
+## Program written to create pbkdf2 hashes that mosquitto-auth-plug will accept.
+
+##Complile mosquitto-auth-plug with -DRAW_SALT flag (you could add this in the config.mk file to CFG_CFLAGS)
+
+
+-- SEE BELOW
+
+# Specify optional/additional linker/compiler flags here
+# On macOS, add 
+#	CFG_LDFLAGS = -undefined dynamic_lookup
+# as described in https://github.com/eclipse/mosquitto/issues/244
+#
+# CFG_LDFLAGS = -undefined dynamic_lookup  -L/usr/local/Cellar/openssl/1.0.2l/lib
+# CFG_CFLAGS = -I/usr/local/Cellar/openssl/1.0.2l/include -I/usr/local/Cellar/mosquitto/1.4.12/include
+CFG_LDFLAGS =
+CFG_CFLAGS = -DRAW_SALT
+
+## You can easily change the hashing algorithm by changing the --
+
+   System.Security.Cryptography.HMACSHA256(password)
+
+   to your desired algorithm.  ** you will need to change the final output string to indicate desired algorithm. 
+   
+   Author Mark Talent drop me a note at github@mtalentlive.com let me know if it helped


### PR DESCRIPTION
The code won't work if you don't compile with the -DRAW_SALT flag.  I added a readme.md that indicates what they need to do.  Sorry it wasn't originally included