### PR TITLE
fix for jwt malloc.c:2394: sysmalloc: Assertion

### DIFF
--- a/be-jwt.c
+++ b/be-jwt.c
@@ -177,7 +177,7 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 	_log(LOG_DEBUG, "data=%s", data);
 	//curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-	char *token_header = (char *)malloc(strlen(escaped_token) + 22);
+	char *token_header = (char *)malloc(strlen(escaped_token) + 23);
 	if (token_header == NULL) {
 		_fatal("ENOMEM");
 		return (FALSE);


### PR DESCRIPTION
fix for jwt token_header overflow by one. 

22 is the length of the ""Authorization: Bearer " char array, but sprintf adds null at the end of token_header and that crashed the plugin every time with 

2017-09-12T08:55:50.633878547Z mosquitto: malloc.c:2394: sysmalloc: Assertion `(old_top == initial_top (av) && old_size == 0) || ((unsigned long) (old_size) >= MINSIZE && prev_inuse (old_top) && ((unsigned long) old_end & (pagesize - 1)) == 0)' failed.

I used the this jwt to replicate:

key eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIyNCIsImF1dGgiOltdLCJ0b3BpY3MiOlsiMSIsIjIiLCIzIiwiNCIsIjI2IiwiMzIiXSwiZXhwIjoxNTAyMjg1NzM5fQ.RhpfXZHWf4p3msFgHAmdJPjgrxogPSufOcT8_lLeE5bI1Yme7GkFk7WFt4V-pAEwm3llzzloYgnycSh_y5JYVg

It fails for me every time.