### PR TITLE
Don't cache authentication failure

### DIFF
--- a/backends.h
+++ b/backends.h
@@ -33,15 +33,24 @@
 #ifndef FALSE
 # define FALSE (0)
 #endif
+#ifndef BACKEND_DEFER
+# define BACKEND_DEFER (0)
+#endif
+#ifndef BACKEND_ALLOW
+# define BACKEND_ALLOW (1)
+#endif
 #ifndef BACKEND_ERROR
 # define BACKEND_ERROR (2)
+#endif
+#ifndef BACKEND_DENY
+# define BACKEND_DENY (3)
 #endif
 
 #ifndef __BACKENDS_H
 # define __BACKENDS_H
 
 typedef void (f_kill)(void *conf);
-typedef char *(f_getuser)(void *conf, const char *username, const char *password, int *authenticated);
+typedef int (f_getuser)(void *conf, const char *username, const char *password, char **phash);
 typedef int (f_superuser)(void *conf, const char *username);
 typedef int (f_aclcheck)(void *conf, const char *clientid, const char *username, const char *topic, int acc);
 

--- a/be-cdb.c
+++ b/be-cdb.c
@@ -36,6 +36,7 @@
 #include <fcntl.h>
 #include <cdb.h>
 #include <mosquitto.h>
+#include "backends.h"
 #include "be-cdb.h"
 #include "log.h"
 #include "hash.h"
@@ -84,14 +85,14 @@ void be_cdb_destroy(void *handle)
 	}
 }
 
-char *be_cdb_getuser(void *handle, const char *username, const char *password, int *authenticated)
+int be_cdb_getuser(void *handle, const char *username, const char *password, char **phash)
 {
 	struct cdb_backend *conf = (struct cdb_backend *)handle;
 	char *k, *v = NULL;
 	unsigned klen;
 
 	if (!conf || !username || !*username)
-		return (NULL);
+		return (FALSE);
 
 	k = (char *)username;
 	klen = strlen(k);
@@ -106,7 +107,8 @@ char *be_cdb_getuser(void *handle, const char *username, const char *password, i
 		}
 	}
 
-	return (v);
+	*phash = v;
+	return BACKEND_DEFER;
 }
 
 /*
@@ -153,13 +155,13 @@ int be_cdb_access(void *handle, const char *username, char *topic)
 
 int be_cdb_superuser(void *handle, const char *username)
 {
-	return 0;
+	return BACKEND_DEFER;
 }
 
 int be_cdb_aclcheck(void *handle, const char *clientid, const char *username, const char *topic, int acc)
 {
 	/* FIXME: implement. Currently TRUE */
 
-	return 1;
+	return BACKEND_ALLOW;
 }
 #endif /* BE_CDB */

--- a/be-cdb.h
+++ b/be-cdb.h
@@ -36,7 +36,7 @@ struct cdb_backend {
 
 void *be_cdb_init();
 void be_cdb_destroy(void *handle);
-char *be_cdb_getuser(void *handle, const char *username, const char *password, int *authenticated);
+int be_cdb_getuser(void *handle, const char *username, const char *password, char **phash);
 int be_cdb_access(void *handle, const char *username, char *topic);
 int be_cdb_superuser(void *handle, const char *username);
 int be_cdb_aclcheck(void *handle, const char *clientid, const char *username, const char *topic, int acc);

--- a/be-files.h
+++ b/be-files.h
@@ -31,7 +31,7 @@
 
 void *be_files_init();
 void be_files_destroy(void *handle);
-char *be_files_getuser(void *handle, const char *username, const char *password, int *authenticated);
+int be_files_getuser(void *handle, const char *username, const char *password, char **phash);
 int be_files_superuser(void *handle, const char *username);
 int be_files_aclcheck(void *handle, const char *clientid, const char *username, const char *topic, int access);
 

--- a/be-http.c
+++ b/be-http.c
@@ -98,12 +98,12 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 	struct curl_slist *headerlist=NULL;
 	int re;
 	int respCode = 0;
-	int ok = FALSE;
+	int ok = BACKEND_DEFER;
 	char *url;
 	char *data;
 
 	if (username == NULL) {
-		return (FALSE);
+		return BACKEND_DEFER;
 	}
 
 	clientid = (clientid && *clientid) ? clientid : "";
@@ -112,7 +112,7 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 
 	if ((curl = curl_easy_init()) == NULL) {
 		_fatal("create curl_easy_handle fails");
-		return (FALSE);
+		return BACKEND_ERROR;
 	}
 	if (conf->hostheader != NULL)
 		headerlist = curl_slist_append(headerlist, conf->hostheader);
@@ -127,7 +127,7 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 	url = (char *)malloc(strlen(conf->hostname) + strlen(uri) + 20);
 	if (url == NULL) {
 		_fatal("ENOMEM");
-		return (FALSE);
+		return BACKEND_ERROR;
 	}
 
 	// enable the https
@@ -148,7 +148,7 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 	char *string_envs = (char *)malloc(MAXPARAMSLEN);
 	if (string_envs == NULL) {
 		_fatal("ENOMEM");
-		return (FALSE);
+		return BACKEND_ERROR;
 	}
 
 	memset(string_envs, 0, MAXPARAMSLEN);
@@ -163,14 +163,14 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 		env_num = get_string_envs(curl, conf->aclcheck_envs, string_envs);
 	}
 	if( env_num == -1 ){
-		return (FALSE);
+		return BACKEND_ERROR;
 	}
 	//---- over ----
 
 	data = (char *)malloc(strlen(string_envs) + strlen(escaped_username) + strlen(escaped_password) + strlen(escaped_topic) + strlen(string_acc) + strlen(escaped_clientid) + 50);
 	if (data == NULL) {
 		_fatal("ENOMEM");
-		return (FALSE);
+		return BACKEND_ERROR;
 	}
 	sprintf(data, "%susername=%s&password=%s&topic=%s&acc=%s&clientid=%s",
 		string_envs,
@@ -197,7 +197,7 @@ static int http_post(void *handle, char *uri, const char *clientid, const char *
 	if (re == CURLE_OK) {
 		re = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &respCode);
 		if (re == CURLE_OK && respCode >= 200 && respCode < 300) {
-			ok = TRUE;
+			ok = BACKEND_ALLOW;
 		} else if (re == CURLE_OK && respCode >= 500) {
 			ok = BACKEND_ERROR;
 		} else {
@@ -300,11 +300,11 @@ void be_http_destroy(void *handle)
 	}
 };
 
-char *be_http_getuser(void *handle, const char *username, const char *password, int *authenticated) {
+int be_http_getuser(void *handle, const char *username, const char *password, char **phash) {
 	struct http_backend *conf = (struct http_backend *)handle;
 	int re, try;
 	if (username == NULL) {
-		return NULL;
+		return BACKEND_DEFER;
 	}
 
 	re = BACKEND_ERROR;
@@ -314,10 +314,7 @@ char *be_http_getuser(void *handle, const char *username, const char *password, 
 		try++;
 		re = http_post(handle, conf->getuser_uri, NULL, username, password, NULL, -1, METHOD_GETUSER);
 	}
-	if (re == 1) {
-		*authenticated = 1;
-	}
-	return NULL;
+	return re;
 };
 
 int be_http_superuser(void *handle, const char *username)

--- a/be-http.h
+++ b/be-http.h
@@ -50,7 +50,7 @@ struct http_backend {
 
 void *be_http_init();
 void be_http_destroy(void *conf);
-char *be_http_getuser(void *conf, const char *username, const char *password, int *authenticated);
+int be_http_getuser(void *conf, const char *username, const char *password, char **phash);
 int be_http_superuser(void *conf, const char *username);
 int be_http_aclcheck(void *conf, const char *clientid, const char *username, const char *topic, int acc);
 #endif /* BE_HTTP */

--- a/be-jwt.h
+++ b/be-jwt.h
@@ -48,7 +48,7 @@ struct jwt_backend {
 
 void *be_jwt_init();
 void be_jwt_destroy(void *conf);
-char *be_jwt_getuser(void *conf, const char *token, const char *password, int *authenticated);
+int be_jwt_getuser(void *conf, const char *token, const char *password, char **phash);
 int be_jwt_superuser(void *conf, const char *token);
 int be_jwt_aclcheck(void *conf, const char *clientid, const char *token, const char *topic, int acc);
 #endif /* BE_JWT */

--- a/be-ldap.h
+++ b/be-ldap.h
@@ -34,7 +34,7 @@
 
 void *be_ldap_init();
 void be_ldap_destroy(void *conf);
-char *be_ldap_getuser(void *conf, const char *username, const char *password, int *authenticated);
+int be_ldap_getuser(void *conf, const char *username, const char *password, char **phash);
 int be_ldap_superuser(void *conf, const char *username);
 int be_ldap_aclcheck(void *conf, const char *clientid, const char *username, const char *topic, int acc);
 #endif /* BE_LDAP */

--- a/be-mongo.h
+++ b/be-mongo.h
@@ -31,7 +31,7 @@
 
 void *be_mongo_init();
 void be_mongo_destroy(void *conf);
-char *be_mongo_getuser(void *conf, const char *username, const char *password, int *authenticated);
+int be_mongo_getuser(void *conf, const char *username, const char *password, char **phash);
 int be_mongo_superuser(void *conf, const char *username);
 int be_mongo_aclcheck(void *conf, const char *clientid, const char *username, const char *topic, int acc);
 #endif /* BE_MONGO */

--- a/be-mysql.c
+++ b/be-mysql.c
@@ -163,7 +163,7 @@ static bool auto_connect(struct mysql_backend *conf)
 	return false;
 }
 
-char *be_mysql_getuser(void *handle, const char *username, const char *password, int *authenticated)
+int be_mysql_getuser(void *handle, const char *username, const char *password, char **phash)
 {
 	struct mysql_backend *conf = (struct mysql_backend *)handle;
 	char *query = NULL, *u = NULL, *value = NULL, *v;
@@ -172,20 +172,20 @@ char *be_mysql_getuser(void *handle, const char *username, const char *password,
 	MYSQL_ROW rowdata;
 
 	if (!conf || !conf->userquery || !username || !*username)
-		return (NULL);
+		return BACKEND_DEFER;
 
 	if (mysql_ping(conf->mysql)) {
 		fprintf(stderr, "%s\n", mysql_error(conf->mysql));
 		if (!auto_connect(conf)) {
-			return (NULL);
+			return BACKEND_ERROR;
 		}
 	}
 	if ((u = escape(conf, username, &ulen)) == NULL)
-		return (NULL);
+		return BACKEND_ERROR;
 
 	if ((query = malloc(strlen(conf->userquery) + ulen + 128)) == NULL) {
 		free(u);
-		return (NULL);
+		return BACKEND_ERROR;
 	}
 	sprintf(query, conf->userquery, u);
 	free(u);
@@ -215,7 +215,8 @@ out:
 	mysql_free_result(res);
 	free(query);
 
-	return (value);
+	*phash = value;
+	return BACKEND_DEFER;
 }
 
 /*
@@ -227,13 +228,13 @@ int be_mysql_superuser(void *handle, const char *username)
 	struct mysql_backend *conf = (struct mysql_backend *)handle;
 	char *query = NULL, *u = NULL;
 	long nrows, ulen;
-	int issuper = FALSE;
+	int issuper = BACKEND_DEFER;
 	MYSQL_RES *res = NULL;
 	MYSQL_ROW rowdata;
 
 
 	if (!conf || !conf->superquery)
-		return (FALSE);
+		return BACKEND_DEFER;
 
 	if (mysql_ping(conf->mysql)) {
 		fprintf(stderr, "%s\n", mysql_error(conf->mysql));
@@ -267,7 +268,7 @@ int be_mysql_superuser(void *handle, const char *username)
 	if ((rowdata = mysql_fetch_row(res)) == NULL) {
 		goto out;
 	}
-	issuper = atoi(rowdata[0]);
+	issuper = (atoi(rowdata[0])) ? BACKEND_ALLOW: BACKEND_DEFER;
 
 out:
 
@@ -293,13 +294,13 @@ int be_mysql_aclcheck(void *handle, const char *clientid, const char *username, 
 	struct mysql_backend *conf = (struct mysql_backend *)handle;
 	char *query = NULL, *u = NULL, *v;
 	long ulen;
-	int match = 0;
+	int match = BACKEND_DEFER;
 	bool bf;
 	MYSQL_RES *res = NULL;
 	MYSQL_ROW rowdata;
 
 	if (!conf || !conf->aclquery)
-		return (FALSE);
+		return BACKEND_DEFER;
 
 	if (mysql_ping(conf->mysql)) {
 		fprintf(stderr, "%s\n", mysql_error(conf->mysql));
@@ -342,7 +343,7 @@ int be_mysql_aclcheck(void *handle, const char *clientid, const char *username, 
 			t_expand(clientid, username, v, &expanded);
 			if (expanded && *expanded) {
 				mosquitto_topic_matches_sub(expanded, topic, &bf);
-				match |= bf;
+				if (bf) match = BACKEND_ALLOW;
 				_log(LOG_DEBUG, "  mysql: topic_matches(%s, %s) == %d",
 				     expanded, v, bf);
 

--- a/be-mysql.h
+++ b/be-mysql.h
@@ -33,7 +33,7 @@
 
 void *be_mysql_init();
 void be_mysql_destroy(void *conf);
-char *be_mysql_getuser(void *conf, const char *username, const char *password, int *authenticated);
+int be_mysql_getuser(void *conf, const char *username, const char *password, char **phash);
 int be_mysql_superuser(void *conf, const char *username);
 int be_mysql_aclcheck(void *conf, const char *clientid, const char *username, const char *topic, int acc);
 #endif /* BE_MYSQL */

--- a/be-postgres.h
+++ b/be-postgres.h
@@ -33,7 +33,7 @@
 
 void *be_pg_init();
 void be_pg_destroy(void *conf);
-char *be_pg_getuser(void *conf, const char *username, const char *password, int *authenticated);
+int be_pg_getuser(void *conf, const char *username, const char *password, char **phash);
 int be_pg_superuser(void *conf, const char *username);
 int be_pg_aclcheck(void *conf, const char *clientid, const char *username, const char *topic, int acc);
 #endif /* BE_POSTGRES */

--- a/be-psk.c
+++ b/be-psk.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <mosquitto.h>
+#include "backends.h"
 #include "be-psk.h"
 #include "log.h"
 #include "hash.h"

--- a/be-redis.h
+++ b/be-redis.h
@@ -31,7 +31,7 @@
 
 void *be_redis_init();
 void be_redis_destroy(void *conf);
-char *be_redis_getuser(void *conf, const char *username, const char *password, int *authenticated);
+int be_redis_getuser(void *conf, const char *username, const char *password, char **phash);
 int be_redis_superuser(void *conf, const char *username);
 int be_redis_aclcheck(void *conf, const char *clientid, const char *username, const char *topic, int acc);
 #endif /* BE_REDIS */

--- a/be-sqlite.h
+++ b/be-sqlite.h
@@ -38,7 +38,7 @@ struct sqlite_backend {
 
 void *be_sqlite_init();
 void be_sqlite_destroy(void *handle);
-char *be_sqlite_getuser(void *handle, const char *username, const char *password, int *authenticated);
+int be_sqlite_getuser(void *handle, const char *username, const char *password, char **phash);
 int be_sqlite_access(void *handle, const char *username, char *topic);
 int be_sqlite_superuser(void *handle, const char *username);
 int be_sqlite_aclcheck(void *handle, const char *clientid, const char *username, const char *topic, int acc);


### PR DESCRIPTION
This PR no longer cache error that occur during authentication.

Before this PR, if an authentication failed (e.g. with HTTP backend, server is down or return 500), the plugin returned MOSQ_ERR_AUTH and the result was cached for the duration of auth_cacheseconds.
After this PR, if an authentication failed, the plugin returns MOSQ_ERR_UNKNOWN (which also result in connection refused for the client) and will NOT cache this result.

This will clone behavior of ACL check, that also does not cache backend error.

To support this feature, the getuser method of backends need a way to inform of error condition. To achieve this I've permuted the output parameter authenticated and the return value (password hash for PKDF2), which allow to have a return code.

This return code have 4 values:
* Allow: previously it was when authenticated = True
* Error: added to support this PR
* Defer: previously it was when authenticated = False. It is in this case that password hash is check if not NULL
* Deny: added with this PR. It look odd to have allow, error and defer but not deny. Not currently used by backends