### PR TITLE
use standard PBKDF2 if Django option is undefined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ ifneq ($(BACKEND_FILES), no)
 	OBJS += be-files.o
 endif
 
+ifeq ($(origin SUPPORT_DJANGO_HASHERS), undefined)
+	SUPPORT_DJANGO_HASHERS = no
+endif
+
 ifneq ($(SUPPORT_DJANGO_HASHERS), no)
 	CFG_CFLAGS += -DSUPPORT_DJANGO_HASHERS
 endif


### PR DESCRIPTION
This commit fixes backward compatibility of the config.mk file (#303).
The plugin now defaults to the standard $PBKDF2$ convention instead of the Django _pbkdf2_ convention if the SUPPORT_DJANGO_HASHERS option is left undefined.