### PR TITLE
Fix logging with Mosquitto >= 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Options therein with a leading ```auth_opt_``` are handed to the plugin. The fol
 | -------------- | ---------- | :---------: | --------------------- |
 | backends       |            |     Y       | comma-separated list of back-ends to load |
 | superusers     |            |             | fnmatch(3) case-sensitive string
-| log_quiet      | false      |             | don't log DEBUG messages |
+| log_quiet      | false      |             | Only used when build with Mosquitto < 1.4: don't log DEBUG messages. With Mosquitto >= 1.4, configure Mosquitto logger (log_type) |
 
 Individual back-ends have their options described in the sections below.
 

--- a/log.h
+++ b/log.h
@@ -27,8 +27,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <mosquitto.h>
+#if (LIBMOSQUITTO_MAJOR > 1) || ((LIBMOSQUITTO_MAJOR == 1) && (LIBMOSQUITTO_MINOR >= 4))
+#define LOG_DEBUG (MOSQ_LOG_DEBUG)
+#define LOG_NOTICE (MOSQ_LOG_NOTICE)
+#else
 #define LOG_DEBUG (1)
 #define LOG_NOTICE (2)
+#endif
 
 extern void (*_log)(int priority, const char *fmt, ...);
 


### PR DESCRIPTION
Following #299, logging use mosquitto_log_printf. But Mosquitto don't use the value 1 for debug priority (it use 0x10).
This use the correct value by using Mosquitto include file.

Also update README to state that log_quiet is no longer used with Mosquitto >= 1.4