### PR TITLE
Add cache jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,25 @@ Options therein with a leading ```auth_opt_``` are handed to the plugin. The fol
 | backends       |            |     Y       | comma-separated list of back-ends to load |
 | superusers     |            |             | fnmatch(3) case-sensitive string
 | log_quiet      | false      |             | don't log DEBUG messages |
+| cacheseconds   |                   |             | Deprecated. Alias for acl_cacheseconds
+| acl_cacheseconds  | 300               |             | number of seconds to cache ACL lookups. 0 disables
+| auth_cacheseconds | 0                 |             | number of seconds to cache AUTH lookups. 0 disables
+| acl_cachejitter   | 0                 |             | maximum number of seconds to add/remove to ACL lookups cache TTL. 0 disables
+| auth_cachejitter  | 0                 |             | maximum number of seconds to add/remove to AUTH lookups cache TTL. 0 disables
 
 Individual back-ends have their options described in the sections below.
+
+There is two cache, one for ACL and another for authentication. By default only ACL cache is enabled.
+
+After a backend responded (postitively or negatively) for an ACL or AUTH lookup, the result will be kept in cache for
+the configured TTL, the same ACL lookup will be served from the cache as long as the TTL is valid.
+The configured TTL is the auth/acl_cacheseconds combined with a random value between -auth/acl_cachejitter and +auth/acl_cachejitter.
+For example, with an acl_cacheseconds of 300 and acl_cachejitter of 10, ACL lookup TTL are distributed between 290 and 310 seconds.
+
+Settings auth/acl_cachejitter to 0 disable any randomization of cache TTL. Settings auth/acl_cacheseconds to 0 disable caching entierly.
+Caching is useful when your backend lookup is expensive. Remember that ACL lookup will be performed for each messages send/received on a topic.
+Jitter is useful to reduce loopups storm that could occur every auth/acl_cacheseconds if lots of clients connected at the same time (for example
+after a server restart, all your clients may reconnect immediatly and all may cause ACL lookups every acl_cacheseconds).
 
 ### MySQL
 
@@ -135,9 +152,6 @@ The following `auth_opt_` options are supported by the mysql back-end:
 | mysql_opt_reconnect | true         |             | enable MYSQL_OPT_RECONNECT option
 | mysql_auto_connect  | true         |             | enable auto_connect function
 | anonusername   | anonymous         |             | username to use for anonymous connections
-| cacheseconds   |                   |             | Deprecated. Alias for acl_cacheseconds
-| acl_cacheseconds  | 300               |             | number of seconds to cache ACL lookups. 0 disables
-| auth_cacheseconds | 0                 |             | number of seconds to cache AUTH lookups. 0 disables
 | ssl_enabled    | false 	     |		   | enable SSL 
 | ssl_key        |   	 	     |		   | path name of client private key file
 | ssl_cert       | 	 	     |		   | path name of client public key certificate file  

--- a/auth-plug.c
+++ b/auth-plug.c
@@ -131,6 +131,8 @@ int mosquitto_auth_plugin_init(void **userdata, struct mosquitto_auth_opt *auth_
 	ud->anonusername = strdup("anonymous");
 	ud->acl_cacheseconds = 300;
 	ud->auth_cacheseconds = 0;
+	ud->acl_cachejitter = 0;
+	ud->auth_cachejitter = 0;
 	ud->aclcache = NULL;
 	ud->authcache = NULL;
 
@@ -155,6 +157,10 @@ int mosquitto_auth_plugin_init(void **userdata, struct mosquitto_auth_opt *auth_
 			ud->acl_cacheseconds = atol(o->value);
 		if (!strcmp(o->key, "auth_cacheseconds"))
 			ud->auth_cacheseconds = atol(o->value);
+		if (!strcmp(o->key, "acl_cachejitter"))
+			ud->acl_cachejitter = atol(o->value);
+		if (!strcmp(o->key, "auth_cacheijitter"))
+			ud->auth_cachejitter = atol(o->value);
 		if (!strcmp(o->key, "log_quiet")) {
 			if(!strcmp(o->value, "false") || !strcmp(o->value, "0")){
 				log_quiet = 0;

--- a/cache.h
+++ b/cache.h
@@ -37,7 +37,7 @@
 struct cacheentry {
         char hex[SHA_DIGEST_LENGTH * 2 + 1];    /* key within struct */
         int granted;
-        time_t seconds;
+        time_t expire_time;
         UT_hash_handle hh;
 };
 

--- a/userdata.h
+++ b/userdata.h
@@ -40,8 +40,10 @@ struct userdata {
 	int fallback_be;		/* Backend to use for anonymous connections */
 	char *anonusername;		/* Configured name of anonymous MQTT user */
 	time_t acl_cacheseconds;		/* number of seconds to cache ACL lookups */
+	time_t acl_cachejitter;		/* number of seconds to add/remove to cache ACL lookups TTL */
 	struct cacheentry *aclcache;
 	time_t auth_cacheseconds;		/* number of seconds to cache AUTH lookups */
+	time_t auth_cachejitter;		/* number of seconds to add/remove to cache AUTH lookups TTL */
 	struct cacheentry *authcache;
 };
 


### PR DESCRIPTION
Added a cache TTL jitter. As explained in README this should reduce lookups storm on backend when lots of client reconnect as the same time. This could easily occur when the Mosquitto server is restarted: all clients get disconnected and will all reconnect quickly. This will cause a storm of lookups (can't really avoid this one, cache is in memory and process was restarted). But without any jitter, every acl_cacheseconds a new lookup storm will happen.
By adding a random jitter, this storm will be spread over a larger time avoiding a high load spike.

To keep compatibility, default value is 0 (disabled). Also updated the README to:

* Move cache options to global section (instead of MySQL one, cache is not MySQL specific).
* Added a short explanation of cache and jitter and why it's useful.