### PR TITLE
Fixed warnings for this to build cleanly with gcc 7.3.0.

### DIFF
--- a/be-postgres.c
+++ b/be-postgres.c
@@ -389,7 +389,7 @@ int addKeyValue(char **keywords, char **values, char *key, char *value,
 	}
 
 	// Get length of dictionary
-	while (*(keywords + n) != '\0')
+	while (keywords[n] != NULL)
 	{
 		n++;
 	}
@@ -401,7 +401,7 @@ int addKeyValue(char **keywords, char **values, char *key, char *value,
 	}
 
 	// Check for dictionary end
-	if ((keywords[n] != '\0') || (values[n] != '\0')){
+	if ((keywords[n] != NULL) || (values[n] != NULL)){
 		// Dictionary wasn't initialized properly or it is the
 		// dictionaries end. --> Abort
 		return -2;


### PR DESCRIPTION
This fixes the following:

```
cc  -I/mqtt/mosquitto/src/ -I/mqtt/mosquitto/lib/ -fPIC -Wall -Werror  -DBE_CDB -DBE_POSTGRES -DBE_HTTP -DBE_JWT -DBE_FILES  -Icontrib/tinycdb-0.78// -I`pg_config --includedir` -I/src -DDEBUG=1 -I/mqtt/openssl/include   -c -o be-postgres.o be-postgres.c
be-postgres.c: In function 'addKeyValue':
be-postgres.c:392:25: error: comparison between pointer and zero character constant [-Werror=pointer-compare]
  while (*(keywords + n) != '\0')
                         ^~
be-postgres.c:392:9: note: did you mean to dereference the pointer?
  while (*(keywords + n) != '\0')
         ^
be-postgres.c:404:19: error: comparison between pointer and zero character constant [-Werror=pointer-compare]
  if ((keywords[n] != '\0') || (values[n] != '\0')){
                   ^~
be-postgres.c:404:7: note: did you mean to dereference the pointer?
  if ((keywords[n] != '\0') || (values[n] != '\0')){
       ^
be-postgres.c:404:42: error: comparison between pointer and zero character constant [-Werror=pointer-compare]
  if ((keywords[n] != '\0') || (values[n] != '\0')){
                                          ^~
be-postgres.c:404:32: note: did you mean to dereference the pointer?
  if ((keywords[n] != '\0') || (values[n] != '\0')){
                                ^
cc1: all warnings being treated as errors
<builtin>: recipe for target 'be-postgres.o' failed
```