### PR TITLE
Compile with mosquitto 1.5 (wip)

### DIFF
--- a/log.c
+++ b/log.c
@@ -42,7 +42,9 @@ void (*_log)(int priority, const char *fmt, ...);
 
 void log_init(void)
 {
-#if (LIBMOSQUITTO_MAJOR > 1) || ((LIBMOSQUITTO_MAJOR == 1) && (LIBMOSQUITTO_MINOR >= 4))
+#if MOSQ_AUTH_PLUGIN_VERSION >= 3
+	_log = __log;
+#elif (LIBMOSQUITTO_MAJOR > 1) || ((LIBMOSQUITTO_MAJOR == 1) && (LIBMOSQUITTO_MINOR >= 4))
 	_log = mosquitto_log_printf;
 #else
 	_log = __log;

--- a/userdata.h
+++ b/userdata.h
@@ -34,6 +34,13 @@
 #ifndef __USERDATA_H
 # define _USERDATA_H
 
+struct cliententry {
+	void *key;
+	char *username;
+	char *clientid;
+	UT_hash_handle hh;
+};
+
 struct userdata {
 	struct backend_p **be_list;
 	char *superusers;		/* Static glob list */
@@ -45,6 +52,7 @@ struct userdata {
 	time_t auth_cacheseconds;		/* number of seconds to cache AUTH lookups */
 	time_t auth_cachejitter;		/* number of seconds to add/remove to cache AUTH lookups TTL */
 	struct cacheentry *authcache;
+	struct cliententry *clients;
 };
 
 #endif


### PR DESCRIPTION
There is still issue to be fixed:

* The hash which provide association with client to username is never purged and will grow forever.
* Client is added to the hash even if it will be rejected, which may be useless.
* clientid is no longer available to ACL check
* PSK authenticated client are probably not working

Still this PR allow to build mosquitto-auth-plug on Mosquitto 1.4 and with Mosquitto develop branch/1.5