### PR TITLE
Mongo backend: support expansion of %c and %u

### DIFF
--- a/backends.c
+++ b/backends.c
@@ -38,9 +38,10 @@
  * new malloc'd string at `res' with those tokens interpolated into it.
  */
 
-void t_expand(const char *clientid, const char *username, char *in, char **res)
+void t_expand(const char *clientid, const char *username, const char *in, char **res)
 {
-	char *s, *work, *wp;
+	const char *s;
+	char *work, *wp;
 	int c_specials = 0, u_specials = 0, len;
 	const char *ct, *ut;
 

--- a/backends.h
+++ b/backends.h
@@ -54,6 +54,6 @@ typedef int (f_getuser)(void *conf, const char *username, const char *password, 
 typedef int (f_superuser)(void *conf, const char *username);
 typedef int (f_aclcheck)(void *conf, const char *clientid, const char *username, const char *topic, int acc);
 
-void t_expand(const char *clientid, const char *username, char *in, char **res);
+void t_expand(const char *clientid, const char *username, const char *in, char **res);
 
 #endif


### PR DESCRIPTION
Add support for expansion of `%c` and `%u` as clientid and username
respectively (just like the mysql backend).

Example: say the ACL for user 'example-user' contains the topic `users/%u/demo`.
This user is then granted access to the expanded topic `users/example-user/demo`.

As this feature already exists for the mysql backend, I modeled this patch after the mysql backend code.

Because `permitted_topic` is of type `const char *` in the mongo backend, I have modified function `t_expand` to expect a `const char *in`.