### PR TITLE
Merged PR https://github.com/manolodd/mosquitto-pbkdf2/pull/2 

### DIFF
--- a/contrib/nodejs/README.md
+++ b/contrib/nodejs/README.md
@@ -4,7 +4,7 @@ mosquitto-pbkdf2
 
 A small module to generate/validate PBKDF2-sha256 passwords as required by mosquitto-auth-plug in node.js 
 
-Usage
+USAGE
 =====
 
 
@@ -25,7 +25,7 @@ verifyCredentials(password, PBKDF2Hash, callback);
 
 See test.js for a more detailed example.
 
-License
+LICENSE
 =======
 
 MIT :-)

--- a/contrib/nodejs/package.json
+++ b/contrib/nodejs/package.json
@@ -1,7 +1,8 @@
 {
   "name": "mosquitto-pbkdf2",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Small module to generate/verify PBKDF2 as needed by mosquitto-auth-plug",
+  "license": "MIT",
   "main": "mosquitto_pbkdf2.js",
   "scripts": {
     "test": "node test.js",
@@ -22,12 +23,18 @@
       "name": "Daniel Jimenez Jerez",
       "email": "unknown@unknown.com",
       "url": "https://github.com/djimenezjerez"
+    },
+    {
+      "name": "Stefan Seide",
+      "email": "unknown@unknown.com",
+      "url": "https://github.com/sseide"
     }
+
   ],
   "repository": "https://github.com/manolodd/mosquitto-pbkdf2",
   "dependencies": {
     "pbkdf2": "3.0.14",
-    "prompt": "1.0.0"
+    "promptly": "3.0.3"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
The library "prompt" for the simple test script requires another lib with a security bug. The automatic snyk test tool flags this as low severity. As both libs (prompt and utile) are not updated for a long time Stefan Seide changed the np.js script to use another more actively maintained library without security warning.

✗ Low severity vulnerability found in utile
  Description: Uninitialized Memory Exposure
  Info: https://snyk.io/vuln/npm:utile:20180614
  Introduced through: mosquitto-pbkdf2@0.2.1
  From: mosquitto-pbkdf2@0.2.1 > prompt@1.0.0 > utile@0.3.0
