### PR TITLE
There is no mosquitto_client_id() or client in MOSQ_AUTH_PLUGIN_VERSI…

### DIFF
--- a/auth-plug.c
+++ b/auth-plug.c
@@ -552,7 +552,11 @@ int mosquitto_auth_unpwd_check(void *userdata, const char *username, const char 
 			free(phash);
 			phash = NULL;
 		}
+#if MOSQ_AUTH_PLUGIN_VERSION >=3	
 		rc = b->getuser(b->conf, username, password, &phash, mosquitto_client_id(client));
+#else
+		rc = b->getuser(b->conf, username, password, &phash, NULL);
+#endif
 		if (rc == BACKEND_ALLOW) {
 			backend_name = (*bep)->name;
 			authenticated = TRUE;


### PR DESCRIPTION
One of the reasons that latest commit does not build with `mosquitto <v1.5`.