### PR TITLE
pbkdf2-check: fix leaks on error paths

### DIFF
--- a/pbkdf2-check.c
+++ b/pbkdf2-check.c
@@ -124,11 +124,14 @@ int pbkdf2_check(char *password, char *hash)
 
 	if ((rawSalt = malloc(strlen(salt) + 1)) == NULL) {
 		fprintf(stderr, "Out of memory\n");
+		free(out);
 		return FALSE;
 	}
 
 	saltlen = base64_decode(salt, rawSalt);
 	if (saltlen < 1) {
+		free(rawSalt);
+		free(out);
 		return (FALSE);
 	}
 


### PR DESCRIPTION
Spotted by cppcheck. Compile tested only.